### PR TITLE
Avoid terminate

### DIFF
--- a/bluesky_widgets/qt/search_results.py
+++ b/bluesky_widgets/qt/search_results.py
@@ -34,7 +34,16 @@ class DataLoader(QThread):
     """
 
     def __init__(self, queue, get_data, data, data_changed, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        # Because the run method contains an infinite loop (standing by to
+        # receive work when additional rows are fetched or when the
+        # results catalog is refreshed) stopping it requires a special pattern.
+        #
+        # Note that parent=None here. If we make the parent the
+        # _SearchResultsModel, it will kill this thread immediately after it
+        # fires the `destroyed` signal, which does not give us time to process
+        # that `destroyed` signal and notice that an interruption has been
+        # requested before we are killed.
+        super().__init__(*args, parent=None, **kwargs)
         self._queue = queue
         self._get_data = get_data
         self._data = data

--- a/bluesky_widgets/qt/search_results.py
+++ b/bluesky_widgets/qt/search_results.py
@@ -108,7 +108,8 @@ class _SearchResultsModel(QAbstractTableModel):
         self._data_loader = DataLoader(
             self._request_queue, self.model.get_data, self._data, self.dataChanged
         )
-        self._data_loader.start()
+        # The DataLoader thread is not started here. It will be started if/when
+        # we need it for the first time.
         self.destroyed.connect(self._data_loader.requestInterruption)
 
         # Changes to the model update the GUI.
@@ -145,6 +146,10 @@ class _SearchResultsModel(QAbstractTableModel):
         rows_to_add = min(remainder, CHUNK_SIZE)
         if rows_to_add <= 0:
             return
+        # Lazily start the DataLoader thread just when we need it for the first
+        # time.
+        if not self._data_loader.isRunning():
+            self._data_loader.start()
         self.beginInsertRows(
             parent, self._current_num_rows, self._current_num_rows + rows_to_add - 1
         )

--- a/bluesky_widgets/qt/search_results.py
+++ b/bluesky_widgets/qt/search_results.py
@@ -51,11 +51,11 @@ class DataLoader(QThread):
         # Process work from the queue, periodically checking to see if we need
         # to shutdown.
         logger.debug("DataLoader starting")
+        CHECK_FOR_SHUTDOWN_PERIOD = 0.1
         while True:
             if self._shutdown_requested:
                 logger.debug("DataLoader exiting")
                 break
-            CHECK_FOR_SHUTDOWN_PERIOD = 0.1
             try:
                 index = self._queue.get(timeout=CHECK_FOR_SHUTDOWN_PERIOD)
             except queue.Empty:

--- a/bluesky_widgets/qt/search_results.py
+++ b/bluesky_widgets/qt/search_results.py
@@ -105,7 +105,7 @@ class _SearchResultsModel(QAbstractTableModel):
             self.model.get_data,
             self._data,
             self.dataChanged,
-            parent=self,
+            parent=None,
         )
 
         def stop_data_loader():
@@ -116,6 +116,7 @@ class _SearchResultsModel(QAbstractTableModel):
             # Wait for the polling loop in DataLoader to process the interruption
             # request.
             data_loader.wait()
+            data_loader.deleteLater()
 
         # When this Python object is destroyed by Qt, gracefully stop the
         # DataLoader QThread before Qt destroys it.

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,7 @@ with open(path.join(here, "requirements.txt")) as requirements_file:
         if not line.startswith("#")
     ]
 
-extras_require = {
-    "pyside2": ["PySide2", "qtpy"],
-    "pyqt5": ["PyQt5", "qtpy"]
-}
+extras_require = {"pyside2": ["PySide2", "qtpy"], "pyqt5": ["PyQt5", "qtpy"]}
 
 setup(
     name="bluesky-widgets",


### PR DESCRIPTION
Closes #3 

Debug logging shows that the DataLoader does shutdown cleanly as intended when
the app is closed. Pending further comment from @ronpandolfi on #3 about
whether we need to reach up to an application signal as well to cover some
scenario we haven't thought of.