### PR TITLE
Ergonomic entry followup

### DIFF
--- a/bluesky_widgets/_qt/tests/test_qt_search.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search.py
@@ -26,3 +26,4 @@ def test_searches(make_test_searches):
     searches = make_test_searches()
     searches[0].input.since = datetime(1980, 2, 2)
     searches[0].input.since = datetime(1985, 11, 15)
+    searches[0].input.since = timedelta(days=-1)

--- a/bluesky_widgets/_qt/tests/test_qt_search.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import pytest
 from ...examples.qt_search import Searches
 
@@ -22,11 +22,7 @@ def make_test_searches(qtbot, request):
 
 
 def test_searches(make_test_searches):
-    make_test_searches()
-
-
-def test_manipulating_times(make_test_searches):
+    "An integration test"
     searches = make_test_searches()
-    searches[0].input.since = 0
+    searches[0].input.since = datetime(1980, 2, 2)
     searches[0].input.since = datetime(1985, 11, 15)
-    searches[0].input.until = datetime(1985, 11, 15)

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -77,7 +77,7 @@ def test_time_input_relative_from_model(qtbot, delta, radio_button):
     actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
     assert abs(actual_until - expected_until) < TOLERANCE
 
-    # And a radio button checks.
+    # And a radio button is checked.
     radio_button_widget = getattr(view, radio_button)
     radio_button_widget.isChecked()
 
@@ -107,12 +107,13 @@ def test_time_input_from_radio_buttons(qtbot, delta, radio_button):
     # should update, reevaluating their relative times with respect to the
     # current time.
     time.sleep(1)
-
     model.request_reload()
+
     # Since and until should update with respect to current time.
     new_actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
     new_actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
     assert actual_since != new_actual_since
     assert actual_until != new_actual_until
+
     # And button should still be checked.
     radio_button_widget.isChecked()

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -8,7 +8,7 @@ from ...components.search.search_input import SearchInput, LOCAL_TIMEZONE
 
 def as_datetime(qdatetime):
     assert isinstance(qdatetime, QDateTime)
-    return qdatetime.toPyDateTime().replace(tzinfo=LOCAL_TIMEZONE)
+    return QDateTime.toPython(qdatetime).replace(tzinfo=LOCAL_TIMEZONE)
 
 
 def datetime_round_trip(dt):

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -2,15 +2,29 @@ from datetime import datetime, timedelta
 import time
 import pytest
 from qtpy.QtCore import QDateTime
-from ...qt.search_input import QtSearchInput, ADA_LOVELACE_BIRTHDAY
-from ...components.search.search_input import SearchInput
+from ...qt.search_input import QtSearchInput, ADA_LOVELACE_BIRTHDAY, as_qdatetime
+from ...components.search.search_input import SearchInput, LOCAL_TIMEZONE
 
 
-def as_qdatetime(datetime):
-    "Create QDateTime set as specified by datetime."
-    qdatetime = QDateTime()
-    qdatetime.setSecsSinceEpoch(datetime.timestamp())
-    return qdatetime
+def as_datetime(qdatetime):
+    assert isinstance(qdatetime, QDateTime)
+    return qdatetime.toPyDateTime().replace(tzinfo=LOCAL_TIMEZONE)
+
+
+def datetime_round_trip(dt):
+    return as_datetime(as_qdatetime(dt))
+
+
+def test_datetime_and_QDateTime_round_trip():
+    """
+    Converting datetime -> QDateTime -> datetime should round trip.
+
+    Test on a recent time (now) and an old time (ADA_LOVELACE_BIRTHDAY).
+    """
+    # Current time with only seconds resolution
+    now = datetime.now(LOCAL_TIMEZONE).replace(microsecond=0)
+    assert datetime_round_trip(now) == now
+    assert datetime_round_trip(ADA_LOVELACE_BIRTHDAY) == ADA_LOVELACE_BIRTHDAY
 
 
 def test_initial_state(qtbot):

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import time
 import pytest
 from qtpy.QtCore import QDateTime
-from ...qt.search_input import QtSearchInput
+from ...qt.search_input import QtSearchInput, ADA_LOVELACE_BIRTHDAY
 from ...components.search.search_input import SearchInput
 
 
@@ -11,6 +11,26 @@ def as_qdatetime(datetime):
     qdatetime = QDateTime()
     qdatetime.setSecsSinceEpoch(datetime.timestamp())
     return qdatetime
+
+
+def test_initial_state(qtbot):
+    "Check that 'All' is checked and since/until are set as expected."
+    model = SearchInput()
+    view = QtSearchInput(model)
+    TOLERANCE = timedelta(seconds=10)
+
+    # Check state of model...
+    assert model.since == ADA_LOVELACE_BIRTHDAY
+    # ...and view.
+    actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    assert actual_since == ADA_LOVELACE_BIRTHDAY
+
+    assert model.until == timedelta(0)
+    actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert actual_until - datetime.now() < TOLERANCE
+
+    # Verify that 'All' radio button is checked.
+    assert view.all_widget.isChecked()
 
 
 def test_time_input_absolute_from_model(qtbot):

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -79,7 +79,7 @@ def test_time_input_relative_from_model(qtbot, delta, radio_button):
 
     # And a radio button is checked.
     radio_button_widget = getattr(view, radio_button)
-    radio_button_widget.isChecked()
+    assert radio_button_widget.isChecked()
 
 
 @pytest.mark.parametrize('delta, radio_button', DELTAS_AND_BUTTONS)
@@ -116,4 +116,4 @@ def test_time_input_from_radio_buttons(qtbot, delta, radio_button):
     assert actual_until != new_actual_until
 
     # And button should still be checked.
-    radio_button_widget.isChecked()
+    assert radio_button_widget.isChecked()

--- a/bluesky_widgets/_qt/tests/test_qt_search_input.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search_input.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+import time
+import pytest
+from qtpy.QtCore import QDateTime
+from ...qt.search_input import QtSearchInput
+from ...components.search.search_input import SearchInput
+
+
+def as_qdatetime(datetime):
+    "Create QDateTime set as specified by datetime."
+    qdatetime = QDateTime()
+    qdatetime.setSecsSinceEpoch(datetime.timestamp())
+    return qdatetime
+
+
+def test_time_input_absolute_from_model(qtbot):
+    "Set the model to a datetime and verify that the view updates."
+    model = SearchInput()
+    view = QtSearchInput(model)
+
+    # Set since.
+    expected_since = datetime(1980, 2, 2)
+    model.since = expected_since
+    actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    assert actual_since == expected_since
+
+    # Set until.
+    expected_until = datetime(1986, 11, 15)
+    model.until = expected_until
+    actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert actual_until == expected_until
+
+
+def test_time_input_absolute_from_datetime_picker(qtbot):
+    "Set the view QDateTime inputs and verify that the model updates."
+    model = SearchInput()
+    view = QtSearchInput(model)
+
+    # Set since.
+    expected_since = datetime(1980, 2, 2)
+    view.since_widget.setDateTime(as_qdatetime(expected_since))
+    actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    assert actual_since == expected_since
+
+    # Set until.
+    expected_until = datetime(1986, 11, 15)
+    view.until_widget.setDateTime(as_qdatetime(expected_until))
+    actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert actual_until == expected_until
+
+
+# timedeltas and attribute name of corresponding QRadioButton on QtSearchInput
+DELTAS_AND_BUTTONS = [
+        (timedelta(hours=-1), 'hour_widget'),
+        (timedelta(days=-1), 'today_widget'),
+        (timedelta(weeks=-1), 'week_widget'),
+        (timedelta(days=-30), 'month_widget'),
+        (timedelta(days=-365), 'year_widget'),
+]
+
+
+@pytest.mark.parametrize('delta, radio_button', DELTAS_AND_BUTTONS)
+def test_time_input_relative_from_model(qtbot, delta, radio_button):
+    "Set the model to a timedelta and verify that the view updates."
+    model = SearchInput()
+    view = QtSearchInput(model)
+    TOLERANCE = timedelta(seconds=1)
+
+    # Set since.
+    expected_since = datetime.now() + delta
+    model.since = delta
+    actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    assert abs(actual_since - expected_since) < TOLERANCE
+
+    # And until updates automatically.
+    expected_until = datetime.now()
+    actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert abs(actual_until - expected_until) < TOLERANCE
+
+    # And a radio button checks.
+    radio_button_widget = getattr(view, radio_button)
+    radio_button_widget.isChecked()
+
+
+@pytest.mark.parametrize('delta, radio_button', DELTAS_AND_BUTTONS)
+def test_time_input_from_radio_buttons(qtbot, delta, radio_button):
+    "Check the radio buttons in the view and verify that the model updates."
+    model = SearchInput()
+    view = QtSearchInput(model)
+    TOLERANCE = timedelta(seconds=1)
+
+    # Set radio button.
+    radio_button_widget = getattr(view, radio_button)
+    radio_button_widget.setChecked(True)
+
+    # Check since.
+    expected_since = datetime.now() + delta
+    actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    assert abs(actual_since - expected_since) < TOLERANCE
+
+    # Check until.
+    expected_until = datetime.now()
+    actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert abs(actual_until - expected_until) < TOLERANCE
+
+    # Additionally, when the model reloads new results, the QDateTime widets
+    # should update, reevaluating their relative times with respect to the
+    # current time.
+    time.sleep(1)
+
+    model.request_reload()
+    # Since and until should update with respect to current time.
+    new_actual_since = datetime.fromtimestamp(view.since_widget.dateTime().toSecsSinceEpoch())
+    new_actual_until = datetime.fromtimestamp(view.until_widget.dateTime().toSecsSinceEpoch())
+    assert actual_since != new_actual_since
+    assert actual_until != new_actual_until
+    # And button should still be checked.
+    radio_button_widget.isChecked()

--- a/bluesky_widgets/components/search/_tests/test_search_input.py
+++ b/bluesky_widgets/components/search/_tests/test_search_input.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from ..search_input import SearchInput
+from ..search_input import SearchInput, LOCAL_TIMEZONE
 
 
 def test_instantiation():
@@ -18,8 +18,8 @@ def test_since_datetime():
         events.append(event)
 
     s.events.since.connect(cb)
-    s.since = datetime(2015, 9, 5)
-    assert s.since == datetime(2015, 9, 5)
+    s.since = datetime(2015, 9, 5, tzinfo=LOCAL_TIMEZONE)
+    assert s.since == datetime(2015, 9, 5, tzinfo=LOCAL_TIMEZONE)
     assert len(events) == 1
     assert "time" in s.query
     assert "$gte" in s.query["time"]
@@ -50,8 +50,8 @@ def test_until_datetime():
         events.append(event)
 
     s.events.until.connect(cb)
-    s.until = datetime(2015, 9, 5)
-    assert s.until == datetime(2015, 9, 5)
+    s.until = datetime(2015, 9, 5, tzinfo=LOCAL_TIMEZONE)
+    assert s.until == datetime(2015, 9, 5, tzinfo=LOCAL_TIMEZONE)
     assert len(events) == 1
     assert "time" in s.query
     assert "$lt" in s.query["time"]
@@ -119,6 +119,6 @@ def test_time_validator():
     with pytest.raises(ValueError):
         s.since = timedelta(days=-2)
     with pytest.raises(ValueError):
-        s.until = datetime(2015, 9, 5)
+        s.until = datetime(2015, 9, 5, tzinfo=LOCAL_TIMEZONE)
     with pytest.raises(ValueError):
         s.until = timedelta(days=-1)

--- a/bluesky_widgets/components/search/search_input.py
+++ b/bluesky_widgets/components/search/search_input.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 
-import tzlocal
+import dateutil.tz
 
 from .queries import TimeRange, InvertedRange
 from ...utils.event import EmitterGroup, Event
 
-TIMEZONE = tzlocal.get_localzone()
-_epoch = datetime(1970, 1, 1, 0, 0, tzinfo=TIMEZONE)
+LOCAL_TIMEZONE = dateutil.tz.tzlocal()
+_epoch = datetime(1970, 1, 1, 0, 0, tzinfo=LOCAL_TIMEZONE)
 
 
 def secs_since_epoch(datetime):

--- a/bluesky_widgets/components/search/search_input.py
+++ b/bluesky_widgets/components/search/search_input.py
@@ -5,7 +5,12 @@ import tzlocal
 from .queries import TimeRange, InvertedRange
 from ...utils.event import EmitterGroup, Event
 
-TIMEZONE = tzlocal.get_localzone().zone
+TIMEZONE = tzlocal.get_localzone()
+_epoch = datetime(1970, 1, 1, 0, 0, tzinfo=TIMEZONE)
+
+
+def secs_since_epoch(datetime):
+    return (datetime - _epoch) / timedelta(seconds=1)
 
 
 def ensure_abs(*abs_or_rel_times):

--- a/bluesky_widgets/components/search/search_input.py
+++ b/bluesky_widgets/components/search/search_input.py
@@ -36,10 +36,6 @@ class SearchInput:
             reload=Event,
         )
         self._time_validator = None
-        # Initialize defaults. Some front ends (e.g. Qt) cannot have a null
-        # state, so we pick an arbitrary range.
-        self.since = datetime.now() - timedelta(days=365)
-        self.until = datetime.now() + timedelta(days=365)
 
     @property
     def time_validator(self):

--- a/bluesky_widgets/components/search/search_input.py
+++ b/bluesky_widgets/components/search/search_input.py
@@ -79,8 +79,11 @@ class SearchInput:
             self.time_validator(since=since, until=self.until)
         if isinstance(since, (int, float)):
             since = datetime.fromtimestamp(since)
-        if isinstance(since, datetime) and since == self.since:
-            return
+        if isinstance(since, datetime):
+            if since == self.since:
+                return
+            if since.tzinfo is None:
+                since = since.replace(tzinfo=LOCAL_TIMEZONE)
         self._since = since
         self.events.since(date=since)
 
@@ -97,8 +100,11 @@ class SearchInput:
             self.time_validator(since=self.since, until=until)
         if isinstance(until, (int, float)):
             until = datetime.fromtimestamp(until)
-        if isinstance(until, datetime) and until == self.until:
-            return
+        if isinstance(until, datetime):
+            if until == self.until:
+                return
+            if until.tzinfo is None:
+                until = until.replace(tzinfo=LOCAL_TIMEZONE)
         self._until = until
         self.events.until(date=until)
 

--- a/bluesky_widgets/examples/qt_search.py
+++ b/bluesky_widgets/examples/qt_search.py
@@ -78,7 +78,7 @@ def main():
         searches[0]
         searches.active  # i.e. current tab
         searches.active.input.since  # time range
-        searches.active.input.until = datetime(2040, 1, 1)
+        searches.active.input.until
         searches.active.results
         searches.active.selection_as_catalog
         searches.active.selected_uids

--- a/bluesky_widgets/examples/qt_search.py
+++ b/bluesky_widgets/examples/qt_search.py
@@ -3,8 +3,6 @@ Select some runs and click the button. Their IDs will be printed to the
 terminal. In a real application, this could kick off data processing, export,
 or visualization.
 """
-from datetime import datetime
-
 from bluesky_widgets.qt import Window
 from bluesky_widgets.qt import gui_qt
 from bluesky_widgets.components.search.searches import SearchList, Search

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -134,7 +134,7 @@ class QtSearchInput(QWidget):
 
     def on_since_view_changed(self, qdatetime):
         # When GUI is updated
-        self.model.since = qdatetime.toPyDateTime()
+        self.model.since = QDateTime.toPython(qdatetime)
 
     def on_since_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)
@@ -168,7 +168,7 @@ class QtSearchInput(QWidget):
 
     def on_until_view_changed(self, qdatetime):
         # When GUI is updated
-        self.model.until = qdatetime.toPyDateTime()
+        self.model.until = QDateTime.toPython(qdatetime)
 
     def on_until_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -10,12 +10,13 @@ from qtpy.QtWidgets import (
     QRadioButton,
     QGridLayout,
 )
-from ..components.search.search_input import TIMEZONE, secs_since_epoch
+from ..components.search.search_input import LOCAL_TIMEZONE, secs_since_epoch
 
 
 def as_qdatetime(datetime):
     "Create QDateTime set as specified by datetime."
-    return QDateTime.fromSecsSinceEpoch(secs_since_epoch(datetime))
+    return QDateTime.fromSecsSinceEpoch(
+        secs_since_epoch(datetime) - datetime.utcoffset() / timedelta(seconds=1))
 
 
 class QtSearchInput(QWidget):
@@ -123,7 +124,7 @@ class QtSearchInput(QWidget):
         self.all_widget.setChecked(True)
 
     def on_reload(self, event):
-        now = datetime.now(TIMEZONE)
+        now = datetime.now(LOCAL_TIMEZONE)
         if isinstance(self.model.since, timedelta):
             with _blocked(self.since_widget):
                 self.since_widget.setDateTime(as_qdatetime(now + self.model.since))
@@ -137,7 +138,7 @@ class QtSearchInput(QWidget):
 
     def on_since_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)
-        now = datetime.now(TIMEZONE)
+        now = datetime.now(LOCAL_TIMEZONE)
         if isinstance(event.date, timedelta):
             qdatetime = as_qdatetime(now + event.date)
             if event.date == timedelta(minutes=-60):
@@ -231,4 +232,4 @@ def _blocked(qobject):
 # the "All" button is checked. It should be some time old enough that it isn't
 # likely to leave out wanted data. We cheekily choose this birthday as that
 # time.
-ADA_LOVELACE_BIRTHDAY = datetime(1815, 12, 10, tzinfo=TIMEZONE)
+ADA_LOVELACE_BIRTHDAY = datetime(1815, 12, 10, tzinfo=LOCAL_TIMEZONE)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -1,5 +1,4 @@
-import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 from qtpy.QtCore import QDateTime
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -125,7 +124,7 @@ class QtSearchInput(QWidget):
         self.all_widget.clicked.connect(self.on_select_all)
 
     def on_reload(self, event):
-        now = time.time()
+        now = datetime.now().timestamp()
         if isinstance(self.model.since, timedelta):
             self.since_widget.setDateTime(
                 QDateTime.fromSecsSinceEpoch(now + self.model.since.total_seconds()))
@@ -139,7 +138,7 @@ class QtSearchInput(QWidget):
 
     def on_since_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)
-        now = time.time()
+        now = datetime.now().timestamp()
         if isinstance(event.date, timedelta):
             self.since_widget.setDateTime(
                 QDateTime.fromSecsSinceEpoch(now + event.date.total_seconds()))

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -160,7 +160,7 @@ class QtSearchInput(QWidget):
             qdatetime = QDateTime()
             qdatetime.setSecsSinceEpoch(event.date.timestamp())
             self.since_widget.setDateTime(qdatetime)
-            self.uncheck_radiobuttons
+            self.uncheck_radiobuttons()
 
     def on_until_view_changed(self, qdatetime):
         # When GUI is updated
@@ -172,8 +172,7 @@ class QtSearchInput(QWidget):
             qdatetime = QDateTime()
             qdatetime.setSecsSinceEpoch(event.date.timestamp())
             self.until_widget.setDateTime(qdatetime)
-            self.uncheck_radiobuttons
-            self.model.request_reload()
+            self.uncheck_radiobuttons()
 
     def on_select_24h(self):
         self.model.since = timedelta(days=-1)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -130,11 +130,6 @@ class QtSearchInput(QWidget):
     def on_since_view_changed(self, qdatetime):
         # When GUI is updated
         self.model.since = qdatetime.toSecsSinceEpoch()
-        # The UI will be confusing if 'since' is absolute but 'until' is
-        # relative and continually updating, so ensure 'until' is absolute.
-        if isinstance(self.model.until, timedelta):
-            now = datetime.now()
-            self.model.until = now + self.model.until
 
     def on_since_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)
@@ -170,11 +165,6 @@ class QtSearchInput(QWidget):
     def on_until_view_changed(self, qdatetime):
         # When GUI is updated
         self.model.until = qdatetime.toSecsSinceEpoch()
-        # The UI will be confusing if 'until' is absolute but 'since' is
-        # relative and continually updating, so ensure 'since' is absolute.
-        if isinstance(self.model.since, timedelta):
-            now = datetime.now()
-            self.model.since = now + self.model.since
 
     def on_until_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -133,6 +133,11 @@ class QtSearchInput(QWidget):
     def on_since_view_changed(self, qdatetime):
         # When GUI is updated
         self.model.since = qdatetime.toSecsSinceEpoch()
+        # The UI will be confusing if 'since' is absolute but 'until' is
+        # relative and continually updating, so ensure 'until' is absolute.
+        if isinstance(self.model.until, timedelta):
+            now = datetime.now()
+            self.model.until = now + self.model.until
 
     def on_since_model_changed(self, event):
         # When model is updated (e.g. from console or by clicking a QRadioButton)
@@ -165,6 +170,11 @@ class QtSearchInput(QWidget):
     def on_until_view_changed(self, qdatetime):
         # When GUI is updated
         self.model.until = qdatetime.toSecsSinceEpoch()
+        # The UI will be confusing if 'until' is absolute but 'since' is
+        # relative and continually updating, so ensure 'since' is absolute.
+        if isinstance(self.model.since, timedelta):
+            now = datetime.now()
+            self.model.since = now + self.model.since
 
     def on_until_model_changed(self, event):
         # When model is updated (e.g. from console)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -225,4 +225,8 @@ def _blocked(qobject):
     qobject.blockSignals(False)
 
 
+# We need some concrete datetime to show in the "Since" datetime picker when
+# the "All" button is checked. It should be some time old enough that it isn't
+# likely to leave out wanted data. We cheekily choose this birthday as that
+# time.
 ADA_LOVELACE_BIRTHDAY = datetime(1815, 12, 10)

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -83,14 +83,12 @@ class QtSearchInput(QWidget):
         self.since_widget.setCalendarPopup(True)
         self.since_widget.setDisplayFormat("yyyy-MM-dd HH:mm")
         self.layout().addRow("Since:", self.since_widget)
-        self.since_widget.dateTimeChanged.connect(self.uncheck_radiobuttons)
 
         # "Until: <datetime picker>"
         self.until_widget = QDateTimeEdit()
         self.until_widget.setCalendarPopup(True)
         self.until_widget.setDisplayFormat("yyyy-MM-dd HH:mm")
         self.layout().addRow("Until:", self.until_widget)
-        self.until_widget.dateTimeChanged.connect(self.uncheck_radiobuttons)
 
         # Refresh Button
         self.refresh_button = QPushButton("Refresh")


### PR DESCRIPTION
## User-facing changes

- Initialize the time entry with the 'All' button checked.
- Previously, the radio buttons became un-checked after a refresh. If it button is checked before a refresh it should stay checked.

## Test changes

Added unit tests for absolute and relative time entry, covering:
- Input from the model (e.g. console)
- Input from the datetime pickers
- Input from each of the radio buttons

## Implementation changes
- Connect to `QRadioButton`'s `toggled` signal rather than `clicked`, as recommended by docs. (This makes it easier to test against as well.)
- Use `QObject.blockSignals` to ensure that we never get circular loops where the model updates the view which updates the model which updates the view. Employ a custom context manager to ensure that we never forget to UN-block the signals.
- Refactor to use `datetime.now()` instead of `time.time()` so that we are always handling `datetime` or `timedelta`, not a mix of `datetime` and floating point timestamp.
- Define Ada Lovelace's birthday (which we cheekily use as the lower bound on "All" times) as an absolute `datetime` rather than a `timedelta`.
