### PR TITLE
Do not block on opening catalogs

### DIFF
--- a/bluesky_widgets/components/search/searches.py
+++ b/bluesky_widgets/components/search/searches.py
@@ -127,9 +127,9 @@ class Search:
             old = self._root_catalog
         new = old[name]
 
-        # Touch an attribute that will trigger a connection attempt. (It's here
+        # Access an entry to trigger a connection attempt. (It's here
         # that an error would be raised if, say, a database is unreachable.)
-        new.metadata
+        next(new.items())
 
         # If we get this far, it worked.
         self._subcatalogs.append(new)

--- a/bluesky_widgets/qt/searches.py
+++ b/bluesky_widgets/qt/searches.py
@@ -84,15 +84,16 @@ class QtSearch(QWidget):
             name = names[index]
             selector.setEnabled(False)
 
-            def on_failure():
-                logger.exception("Failed to select %r", name)
+            def on_errored(err):
+                logger.exception("Failed to select %r", name, exc_info=err)
+                # Reset the combobox selection to an empty value and enable it.
                 selector.setCurrentIndex(-1)
                 selector.setEnabled(True)
 
             worker = create_worker(
                 self.model.enter,
                 name,
-                _connect={"errored": on_failure}
+                _connect={"errored": on_errored}
             )
 
         selector.activated.connect(on_selection)

--- a/bluesky_widgets/qt/searches.py
+++ b/bluesky_widgets/qt/searches.py
@@ -47,9 +47,7 @@ class QtSearch(QWidget):
         self._back_button.clicked.connect(model.go_back)
 
         # Hook up model Events to Qt Slots.
-        self.model.events.enter.connect(self.on_enter)
         self.model.events.go_back.connect(self.on_go_back)
-        self.model.events.run_search_ready.connect(self.on_run_search_ready)
         self.model.events.run_search_cleared.connect(self.on_run_search_cleared)
 
         self._selector_widgets = []  # QComboBoxes
@@ -69,12 +67,6 @@ class QtSearch(QWidget):
             # box.
             self._initialize_selector(list(model.current_catalog))
 
-    def on_enter(self, event=None):
-        "We are entering a subcatalog."
-        names = list(event.catalog)
-        self._initialize_selector(names)
-        self._back_button.setEnabled(True)
-
     def _initialize_selector(self, names):
         "Create a combobox to select from subcatalogs."
         selector = QtSubcatalogSelector(names)
@@ -90,10 +82,24 @@ class QtSearch(QWidget):
                 selector.setCurrentIndex(-1)
                 selector.setEnabled(True)
 
-            worker = create_worker(
+            def on_success(return_value):
+                # return_value is None
+                if self.model.run_search is None:
+                    # We have a Catalog of Catalogs.
+                    names = list(self.model.current_catalog)
+                    self._initialize_selector(names)
+                else:
+                    # We have a Catalog of Runs.
+                    self._initialize_run_search(
+                        self.model.run_search.search_input,
+                        self.model.run_search.search_results
+                    )
+                self._back_button.setEnabled(True)
+
+            create_worker(
                 self.model.enter,
                 name,
-                _connect={"errored": on_errored}
+                _connect={"errored": on_errored, "returned": on_success}
             )
 
         selector.activated.connect(on_selection)
@@ -112,11 +118,6 @@ class QtSearch(QWidget):
         if not breadcrumbs:
             # This is the last widget. Disable back button.
             self._back_button.setEnabled(False)
-
-    def on_run_search_ready(self, event):
-        "We have a catalog of Runs."
-        self._initialize_run_search(event.search_input, event.search_results)
-        self._back_button.setEnabled(True)
 
     def _initialize_run_search(self, search_input, search_results):
         "Create search input and output for a catalog of Runs."


### PR DESCRIPTION
Closes #25 

We were blocking the main thread on accessing sub-Catalogs. We already use `create_worker` (a nice wrapper around `QRunnable` that we vendored from napari) to access the items in a Catalog. This PR applies that approach to the initial sub-Catalog access as well, which is when MongoDB client--server connection happens and has the potential to hang for 30 seconds.

I tested this against this configuration file, which points to a nonexistent MongoDB deployment.

```
# ~/.local/share/intake/test_not_connectable.yml 
sources:
  broken_example:
    driver: bluesky-mongo-normalized-catalog
    args:
      metadatastore_db: mongodb://localhost:55555/WRONG_PORT_CANNOT_CONNECT
      asset_registry_db: mongodb://localhost:55555/WRONG_PORT_CANNOT_CONNECT
```

When I select this item in the GUI, the combobox is immediately disabled _but the GUI remains responsive_. After 30 seconds (pymongo's default [server selection timeout](https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient)) the traceback is logged, the combox is re-enabled and reset to a blank value.

It would be nice if we could back out before waiting for the timeout---that is, to give the option to cancel the operation before it succeeds for times out. Cancellation is generally difficult to get right, so I would like to punt that to a future PR.

As is, this at least _does not_ lock up the application and _does_ leave it in a usable state after the failure.

Needs a unit test