### PR TITLE
Refactor example

### DIFF
--- a/bluesky_widgets/_qt/tests/test_qt_search.py
+++ b/bluesky_widgets/_qt/tests/test_qt_search.py
@@ -1,29 +1,29 @@
 from datetime import datetime, timedelta
 import pytest
-from ...examples.qt_search import Searches
+from ...examples.qt_search import ExampleApp
 
 
 @pytest.fixture(scope="function")
-def make_test_searches(qtbot, request):
-    searchess = []
+def make_test_app(qtbot, request):
+    apps = []
 
     def actual_factory(*model_args, **model_kwargs):
         model_kwargs["show"] = model_kwargs.pop(
             "show", request.config.getoption("--show-window")
         )
-        searches = Searches(*model_args, **model_kwargs)
-        searchess.append(searches)
-        return searches
+        app = ExampleApp(*model_args, **model_kwargs)
+        apps.append(app)
+        return app
 
     yield actual_factory
 
-    for searches in searchess:
-        searches.close()
+    for app in apps:
+        app.close()
 
 
-def test_searches(make_test_searches):
+def test_app(make_test_app):
     "An integration test"
-    searches = make_test_searches()
-    searches[0].input.since = datetime(1980, 2, 2)
-    searches[0].input.since = datetime(1985, 11, 15)
-    searches[0].input.since = timedelta(days=-1)
+    app = make_test_app()
+    app.searches[0].input.since = datetime(1980, 2, 2)
+    app.searches[0].input.since = datetime(1985, 11, 15)
+    app.searches[0].input.since = timedelta(days=-1)

--- a/bluesky_widgets/examples/qt_search.py
+++ b/bluesky_widgets/examples/qt_search.py
@@ -76,7 +76,7 @@ class ExampleApp:
 
 def main():
     print(__doc__)
-    with gui_qt():
+    with gui_qt("Example App"):
         app = ExampleApp()
 
         # We can access and modify the model as in...

--- a/bluesky_widgets/examples/qt_search.py
+++ b/bluesky_widgets/examples/qt_search.py
@@ -39,47 +39,55 @@ class SearchesWidget(QWidget):
             )
 
 
-class Searches(SearchList):
+class ExampleApp:
     """
     A user-facing model composed with a Qt widget and window.
+
+    A key point here is that the model `searches` is public and can be
+    manipuated from a console, but the view `_window` and all Qt-related
+    components are private. The public `show()` and `close()` methods are the
+    only view-specific actions that are exposed to the user. Thus, this could
+    be implemented in another UI framework with no change to the user-facing
+    programmatic interface.
     """
 
-    def __init__(self, *, show=True, title=""):
+    def __init__(self, *, show=True, title="Example App"):
         super().__init__()
         self.title = title
-        widget = SearchesWidget(self)
-        self.window = Window(widget, show=show)
+        self.searches = SearchList()
+        widget = SearchesWidget(self.searches)
+        self._window = Window(widget, show=show)
 
         # Initialize with a two search tabs: one with some generated example data...
-        self.append(Search(get_catalog(), columns=columns))
+        self.searches.append(Search(get_catalog(), columns=columns))
         # ...and one listing any and all catalogs discovered on the system.
         from databroker import catalog
 
-        self.append(Search(catalog, columns=columns))
+        self.searches.append(Search(catalog, columns=columns))
 
     def show(self):
         """Resize, show, and raise the window."""
-        self.window.show()
+        self._window.show()
 
     def close(self):
         """Close the window."""
-        self.window.close()
+        self._window.close()
 
 
 def main():
     print(__doc__)
-    with gui_qt("Example Application"):
-        searches = Searches(title="Example Application")
+    with gui_qt():
+        app = ExampleApp()
 
         # We can access and modify the model as in...
-        len(searches)
-        searches[0]
-        searches.active  # i.e. current tab
-        searches.active.input.since  # time range
-        searches.active.input.until
-        searches.active.results
-        searches.active.selection_as_catalog
-        searches.active.selected_uids
+        len(app.searches)
+        app.searches[0]
+        app.searches.active  # i.e. current tab
+        app.searches.active.input.since  # time range
+        app.searches.active.input.until
+        app.searches.active.results
+        app.searches.active.selection_as_catalog
+        app.searches.active.selected_uids
 
 
 if __name__ == "__main__":

--- a/bluesky_widgets/qt/search_input.py
+++ b/bluesky_widgets/qt/search_input.py
@@ -16,7 +16,7 @@ from ..components.search.search_input import LOCAL_TIMEZONE, secs_since_epoch
 def as_qdatetime(datetime):
     "Create QDateTime set as specified by datetime."
     return QDateTime.fromSecsSinceEpoch(
-        secs_since_epoch(datetime) - datetime.utcoffset() / timedelta(seconds=1)
+        int(secs_since_epoch(datetime) - datetime.utcoffset() / timedelta(seconds=1))
     )
 
 


### PR DESCRIPTION
Prompted by discussion with @gwbischof, some of which I rehash here for future reference.

Point (3) in the guidelines linked in #31 states:

> Models do not have any dependencies on UI classes (Qt). Views take the corresponding model as the one and unique parameter of their constructor and register listeners so as to be notified about any events in the model, so that the view can change if the model is externally changed. Since the view knows about the model, it can trivially change the model when it itself changes.

All the way down the tree, UI classes take `model` (and nothing else, save for `*args, **kwargs` used by Qt) as their one and unique parameter. But, to build the "outer" model, the "root" of this tree of models, we break that pattern. We subclass a model, and inside it build a widget and window which we sticky-tape onto the model.

https://github.com/bluesky/bluesky-widgets/blob/d52b0e265f764055ee349b9a6671ab87e3512c7c/bluesky_widgets/examples/qt_search.py#L42-L51

Napari [does that same thing](https://github.com/napari/napari/blob/master/napari/viewer.py#L40). (They build their widget inside the `Window` class but the effect is equivalent.) The user gets:

```py
viewer_model = napari.Viewer()  # a model that *has* a view
```

They could have done it like this:

```py
viewer_model, viewer_window = napari.Viewer()  # a tuple of (model, view)
```

That would be cleaner in some sense, and it would avoid breaking the pattern. But they want to treat the Qt window, and indeed all Qt things, and implementation details that might change in the future, so they basically do the equiavlent of
 
```py
viewer_model.window = viewer_window
```

and then hand the user the model. It gets the job done, but I found it confusing when I first read the implementation because now the model has-a view. In our cases, since we want users to be authoring custom applications, it's especially confusing that the first thing they read will _break_ a core pattern used throughout the rest of the library. ("A view has-a model, except here!") To make things clearer, we could instead do

```py
app.model = model
app._window = window
```

where `app` is its own thing, neither a view nor a model, that exposes the model publicly and the view privately. The usage become more verbose but arguably more clear

```py
# Before
searches = Searches()
searches.active.input.since
searches[1].active = True

# After
app = ExampleApp()
app.searches.active.input.since
app.searches[1].active = True
```

and the clarity of the implementation is, I think, definitely improved. It avoids turning the pattern "inside out". A view _always_ takes a model, and at the other-most layer, they are joined via composition into the final user-facing object.