### PR TITLE
Rename handle_click -> process.

### DIFF
--- a/bluesky_widgets/examples/qt_search.py
+++ b/bluesky_widgets/examples/qt_search.py
@@ -17,7 +17,7 @@ class SearchListWithButton(SearchList):
     A SearchList model with a method to handle a click event.
     """
 
-    def handle_click(self):
+    def process(self):
         for uid, run in self.active.selection_as_catalog.items():
             # Pretend to kick off data processing or something.
             print(
@@ -46,7 +46,7 @@ class QtSearchListWithButton(QWidget):
         go_button.clicked.connect(self.on_click)
 
     def on_click(self):
-        self.model.handle_click()
+        self.model.process()
 
 
 class ExampleApp:


### PR DESCRIPTION
When running an app in the console

```py
In [1]: from bluesky_widgets.examples.qt_search import ExampleApp

In [2]: app = ExampleApp()
```

we can reload search results by clicking the "Refresh" button in the view, or by calling `request_reload()` on the appropriate model (which is effectively what clicking the button does) from the commandline.

```py
In [3]: app.searches.active.run_search.search_input.request_reload()
# Yes, this has the word 'search' in it too many times
# and might have too many levels of nesting...
# a problem for another day.
```

With #35 merged, we can now also "process" the selected results from the commandline. This PR gives that method a name that is meaningful in the context of the model.

```py
In [4]: app.searches.process()
Processing Run b50c3273 (scan_id=2)
Processing Run 4e9125f5 (scan_id=1)
```

The fact that it is "handling a click" is a detail of the view.