### PR TITLE
Make Search tabs not closable.

### DIFF
--- a/bluesky_widgets/qt/_searches.py
+++ b/bluesky_widgets/qt/_searches.py
@@ -155,15 +155,12 @@ class QtSearches(QTabWidget):
         self.insertTab(event.index, tab, f"Search {event.item.name}")
 
     def on_removed(self, event):
-        if event.item in self._tabs:
-            # A Search has been removed from the SearchList model.
-            # Close the associated tab and clean up the associated state.
-            widget = self._tabs[event.item]
-            index = self.indexOf(widget)
-            self.removeTab(index)
-            del self._tabs[event.item]
-        # Else we are being notified the removal of a tab/model that we
-        # initiated in close_tab().
+        # A Search has been removed from the SearchList model.
+        # Close the associated tab and clean up the associated state.
+        widget = self._tabs[event.item]
+        index = self.indexOf(widget)
+        self.removeTab(index)
+        del self._tabs[event.item]
 
     def on_active_changed(self, event):
         self.setCurrentWidget(self._tabs[event.item])
@@ -178,9 +175,7 @@ class QtSearches(QTabWidget):
                 break
 
     def close_tab(self, index):
-        # When closing is initiated from the view, remove the associated Search
-        # model from the SearchList model.
+        # Remove the associated Search model from the SearchList model.
+        # Its removal will trigger on_removed above and thereby update the view.
         widget = self.widget(index)
-        self.removeTab(index)
-        del self._tabs[widget.model]
         self.model.remove(widget.model)

--- a/bluesky_widgets/qt/_searches.py
+++ b/bluesky_widgets/qt/_searches.py
@@ -134,7 +134,10 @@ class QtSearches(QTabWidget):
 
     def __init__(self, model, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setTabsClosable(True)
+        # There is no way to *add* tabs in the UI, so for now we will not
+        # permit removing them in the UI either. This could be added in the
+        # future. In the meantime, it is supported from the model / console.
+        self.setTabsClosable(False)
         self.tabCloseRequested.connect(self.close_tab)
         self.currentChanged.connect(self.on_current_changed)
 


### PR DESCRIPTION
Search tabs can be added or removed from the model (e.g. console).
Currently, they can be removed (closed) from the UI but not added. This
seems bad, as you could accidentally close a tab and have no way to get
it back. For now, I think it's better to make the tabs not closable from
the UI.