### PR TITLE
Refactor pinned_runs concept.

### DIFF
--- a/bluesky_widgets/examples/AutoRecentLines.ipynb
+++ b/bluesky_widgets/examples/AutoRecentLines.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.pinned_runs.append(scans[-1])"
+    "model.add_run(scans[-1], pinned=True)"
    ]
   },
   {
@@ -114,86 +114,6 @@
    "source": [
     "RE(plan())"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ipywidgets.widgets import Tab, IntSlider\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "t = Tab()\n",
-    "\n",
-    "def go():\n",
-    "    slider = IntSlider()\n",
-    "    t.children = (slider,)\n",
-    "    slider.on_trait_change(lambda *args, **kwargs: print(args, kwargs), \"value\")\n",
-    "    time.sleep(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "go()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "slider = IntSlider()\n",
-    "slider.on_trait_change(lambda *args, **kwargs: print(args, kwargs), \"value\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "slider"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "time.sleep(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/bluesky_widgets/examples/RecentLines.ipynb
+++ b/bluesky_widgets/examples/RecentLines.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.pinned_runs.append(scans[-1])"
+    "model.add_run(scans[-1], pinned=True)"
    ]
   },
   {

--- a/bluesky_widgets/models/_tests/test_recent_lines.py
+++ b/bluesky_widgets/models/_tests/test_recent_lines.py
@@ -1,0 +1,30 @@
+from ..plot_builders import RecentLines
+from bluesky_live.run_builder import build_simple_run
+
+
+def test_pinning():
+    # Make some runs to use.
+    runs = [
+        build_simple_run(
+            {"motor": [1, 2], "det": [10, 20]}, metadata={"scan_id": 1 + i}
+        )
+        for i in range(10)
+    ]
+    MAX_RUNS = 3
+    model = RecentLines(MAX_RUNS, "motor", "det")
+
+    # Add MAX_RUNS and then some more and check that they do get bumped off.
+    for run in runs[:5]:
+        model.add_run(run)
+        assert len(model.runs) <= MAX_RUNS
+    assert runs[2:5] == list(model.runs)
+
+    # Add a pinned run.
+    pinned_run = runs[5]
+    model.add_run(pinned_run, pinned=True)
+    assert frozenset([pinned_run.metadata["start"]["uid"]]) == model.pinned
+    for run in runs[5:]:
+        model.add_run(run)
+        assert len(model.runs) == 1 + MAX_RUNS
+    # Check that it hasn't been bumpbed off.
+    assert pinned_run in model.runs

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -459,8 +459,7 @@ class AutoRecentLines:
         run : BlueskyRun
         """
         for instance in self._key_to_instance.values():
-            if run in instance.runs:
-                instance.runs.remove(run)
+            instance.discard_run(run)
 
     def _handle_stream(self, run, stream_name, pinned):
         "This examines a stream and adds this run to RecentLines instances."

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -167,8 +167,8 @@ class RecentLines:
     runs : RunList[BlueskyRun]
         As runs are appended entries will be removed from the beginning of the
         last (first in, first out) so that there are at most ``max_runs``.
-    pinned_runs : RunList[BlueskyRun]
-        These runs will not be automatically removed.
+    pinned : Frozenset[String]
+        Run uids of pinned runs.
     figure : FigureSpec
     func : callable
     axes : AxesSpec
@@ -206,7 +206,7 @@ class RecentLines:
         self._func = func
 
         self.runs = RunList()
-        self.pinned_runs = RunList()
+        self._pinned = set()
 
         self._color_cycle = itertools.cycle(f"C{i}" for i in range(10))
         # Maps Run (uid) to LineSpec
@@ -214,8 +214,6 @@ class RecentLines:
 
         self.runs.events.added.connect(self._on_run_added)
         self.runs.events.removed.connect(self._on_run_removed)
-        self.pinned_runs.events.added.connect(self._on_run_added)
-        self.pinned_runs.events.removed.connect(self._on_run_removed)
 
         if axes is None:
             axes = AxesSpec(x_label=self.x, y_label=self.y)
@@ -236,9 +234,8 @@ class RecentLines:
             If True, retain this Run until it is removed by the user.
         """
         if pinned:
-            self.pinned_runs.append(run)
-        else:
-            self.runs.append(run)
+            self._pinned.add(run.metadata["start"]["uid"])
+        self.runs.append(run)
 
     def discard_run(self, run):
         """
@@ -251,8 +248,6 @@ class RecentLines:
         run : BlueskyRun
         """
         if run in self.runs:
-            self.runs.remove(run)
-        if run in self.pinned_runs:
             self.runs.remove(run)
 
     def _add_line(self, run):
@@ -272,7 +267,7 @@ class RecentLines:
         style = {"color": color}
 
         # Style pinned runs differently.
-        if run in self.pinned_runs:
+        if run.metadata["start"]["uid"] in self._pinned:
             style.update(linestyle="dashed")
             label += " (pinned)"
 
@@ -286,8 +281,11 @@ class RecentLines:
 
     def _cull_runs(self):
         "Remove Runs from the beginning of self.runs to keep the length <= max_runs."
-        while len(self.runs) > self.max_runs:
-            self.runs.pop(0)
+        i = 0
+        while len(self.runs) > self.max_runs + len(self._pinned):
+            while self.runs[i].metadata["start"]["uid"] in self._pinned:
+                i += 1
+            self.runs.pop(i)
 
     def _on_run_added(self, event):
         "When a new Run is added, draw a line or schedule it to be drawn."
@@ -302,6 +300,7 @@ class RecentLines:
     def _on_run_removed(self, event):
         "Remove the line if its corresponding Run is removed."
         run_uid = event.item.metadata["start"]["uid"]
+        self._pinned.discard(run_uid)
         try:
             line = self._runs_to_lines.pop(run_uid)
         except KeyError:
@@ -356,6 +355,10 @@ class RecentLines:
     @property
     def func(self):
         return self._func
+
+    @property
+    def pinned(self):
+        return frozenset(self._pinned)
 
 
 class AutoRecentLines:
@@ -458,8 +461,6 @@ class AutoRecentLines:
         for instance in self._key_to_instance.values():
             if run in instance.runs:
                 instance.runs.remove(run)
-            if run in instance.pinned_runs:
-                instance.runs.remove(run)
 
     def _handle_stream(self, run, stream_name, pinned):
         "This examines a stream and adds this run to RecentLines instances."
@@ -468,10 +469,7 @@ class AutoRecentLines:
                 instance = self._key_to_instance[key]
             except KeyError:
                 instance = self.new_instance_for_key(key)
-            if pinned:
-                instance.pinned_runs.append(run)
-            else:
-                instance.runs.append(run)
+            instance.add_run(run, pinned=pinned)
 
     def _on_figure_removed(self, event):
         """


### PR DESCRIPTION
Instead of keeping two separate lists of runs, `pinned_runs` and `runs`,
keep just `runs` and track "pinned" as a set of runs (their `uid`s to be
precise) in that list.

This makes the implementation simpler and avoids the confusing question
whether a run could be in both lists at once. As before, a pinned run
can be added like:

```py
model.add_run(run, pinned=True)
```

and, also as before, a pinned run can be removed the same as an
un-pinned one, by calling

```py
model.discard_run(run)  # doesn't matter if it's pinned or unpinned
```

or removing it from the list by position:

```py
del model.runs[3]  # doesn't matter if it's pinned or unpinned
```

You can effectively "un-pin" a run by removing and then re-adding it.

```py
model.add_run(run, pinned=True)
model.discard_run(run)
model.add_run(run)  # re-add, not pinned
```

(I don't think un-pinning deserves a special method, especially because
it's not clear yet that it will be a common thing to do.)

The set of currently pinned runs (their uids) can be viewed as:

```py
model.pinned  # returns a frozenset of run uids
```