### PR TITLE
More mpl jupyter fixes

### DIFF
--- a/bluesky_widgets/_matplotlib_axes.py
+++ b/bluesky_widgets/_matplotlib_axes.py
@@ -191,7 +191,7 @@ class MatplotlibAxes:
 
     def _update_and_draw(self):
         "Update the legend and redraw the canvas."
-        self.axes.legend(loc="best")  # Update the legend.
+        self.axes.legend(loc=1)  # Update the legend.
         self.draw_idle()  # Ask matplotlib to redraw the figure.
 
 

--- a/bluesky_widgets/examples/AutoRecentLines.ipynb
+++ b/bluesky_widgets/examples/AutoRecentLines.ipynb
@@ -12,8 +12,15 @@
     "\n",
     "from bluesky_widgets.models.plot_builders import AutoRecentLines\n",
     "from bluesky_widgets.jupyter.figures import JupyterFigures\n",
-    "from bluesky_widgets.utils.streaming import stream_documents_into_runs\n",
-    "\n",
+    "from bluesky_widgets.utils.streaming import stream_documents_into_runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "RE = RunEngine()\n",
     "model = AutoRecentLines(3)\n",
     "view = JupyterFigures(model.figures)\n",
@@ -73,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "del model.runs[1]"
+    "RE(plan())"
    ]
   },
   {
@@ -93,6 +100,8 @@
    "source": [
     "# Generate example data. (This takes a couple seconds to simulate some scans.)\n",
     "from bluesky_widgets.examples.utils.generate_msgpack_data import get_catalog\n",
+    "\n",
+    "motor.delay = 0\n",
     "catalog = get_catalog()\n",
     "scans = catalog.search({\"plan_name\": \"scan\"})"
    ]
@@ -114,6 +123,13 @@
    "source": [
     "RE(plan())"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/bluesky_widgets/examples/RecentLines.ipynb
+++ b/bluesky_widgets/examples/RecentLines.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.figures.clear()"
+    "RE(plan())"
    ]
   },
   {

--- a/bluesky_widgets/examples/Streaming.ipynb
+++ b/bluesky_widgets/examples/Streaming.ipynb
@@ -18,21 +18,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from databroker import catalog\n",
-    "results = catalog[\"example\"].search({\"plan_name\": \"scan\"})\n",
-    "app.model.add_run(results[-1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# In a terminal, run\n",
     "# python -m bluesky_widgets.examples.utils.stream_data\n",
     "# and put the address that it prints here:\n",
-    "ADDRESS = \"localhost:45437\""
+    "ADDRESS = ____"
    ]
   },
   {
@@ -42,15 +31,6 @@
    "outputs": [],
    "source": [
     "stop = listen_for_data(app, ADDRESS)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stop()"
    ]
   },
   {

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -196,7 +196,6 @@ def _make_figure(figure_spec):
     # but verify that number of axes created matches the number of axes
     # specified.
     figure, axes = plt.subplots(len(figure_spec.axes))
-    figure.tight_layout()
     # Handle return type instability in plt.subplots.
     if not isinstance(axes, collections.abc.Iterable):
         axes = [axes]

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -10,6 +10,7 @@ from ..utils.dict_view import DictView
 def _initialize_mpl():
     "Set backend to ipympl and import pyplot."
     import matplotlib
+
     matplotlib.use(
         "module://ipympl.backend_nbagg"
     )  # must set before importing matplotlib.pyplot
@@ -106,9 +107,7 @@ class JupyterFigure(widgets.HBox):
         self.figure.suptitle(model.title)
         self._axes = {}
         for axes_spec, axes in zip(model.axes, self.axes_list):
-            self._axes[axes_spec.uuid] = MatplotlibAxes(
-                model=axes_spec, axes=axes
-            )
+            self._axes[axes_spec.uuid] = MatplotlibAxes(model=axes_spec, axes=axes)
         self.children = (self.figure.canvas,)
 
         model.events.title.connect(self._on_title_changed)

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -21,6 +21,7 @@ from ..utils.dict_view import DictView
 def _initialize_matplotlib():
     "Set backend to Qt5Agg and import pyplot."
     import matplotlib
+
     matplotlib.use("Qt5Agg")  # must set before importing matplotlib.pyplot
     import matplotlib.pyplot  # noqa
 

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -11,12 +11,18 @@ from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar,
 )
-import matplotlib
 
 from ..models.plot_specs import FigureSpec, FigureSpecList
 from .._matplotlib_axes import MatplotlibAxes
 from ..utils.event import Event
 from ..utils.dict_view import DictView
+
+
+def _initialize_matplotlib():
+    "Set backend to Qt5Agg and import pyplot."
+    import matplotlib
+    matplotlib.use("Qt5Agg")  # must set before importing matplotlib.pyplot
+    import matplotlib.pyplot  # noqa
 
 
 class ThreadsafeMatplotlibAxes(QObject, MatplotlibAxes):
@@ -48,6 +54,7 @@ class QtFigures(QTabWidget):
     __callback_event = Signal(object, Event)
 
     def __init__(self, model: FigureSpecList, parent=None):
+        _initialize_matplotlib()
         super().__init__(parent)
         self.setTabsClosable(True)
         self.tabCloseRequested.connect(self._on_close_tab_requested)
@@ -146,6 +153,7 @@ class QtFigure(QWidget):
     """
 
     def __init__(self, model: FigureSpec, parent=None):
+        _initialize_matplotlib()
         super().__init__(parent)
         self.model = model
         self.figure, self.axes_list = _make_figure(model)
@@ -190,8 +198,10 @@ class QtFigure(QWidget):
 
 def _make_figure(figure_spec):
     "Create a Figure and Axes."
-    matplotlib.use("Qt5Agg")  # must set before importing matplotlib.pyplot
-    import matplotlib.pyplot as plt  # noqa
+    # This import must be deferred until after the matplotlib backend is set,
+    # which happens when a QtFigure or QtFigures is instantiated
+    # for the first time.
+    import matplotlib.pyplot as plt
 
     # TODO Let FigureSpec give different options to subplots here,
     # but verify that number of axes created matches the number of axes

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -197,7 +197,7 @@ def _make_figure(figure_spec):
     # but verify that number of axes created matches the number of axes
     # specified.
     fig, axes = plt.subplots(len(figure_spec.axes))
-    # Handl return type instability in plt.subplots.
+    # Handle return type instability in plt.subplots.
     if not isinstance(axes, collections.abc.Iterable):
         axes = [axes]
     return fig, axes


### PR DESCRIPTION
This was the result of hours of interactive testing with @tacaswell. The three example notebooks test:

* Streaming from RE (in process) to `JupyterFigure`
* Streaming from RE (in process) to `JupyterFigures`
* Stream via 0MQ (with RE in a separate process) to `JupyterFigures`

and all three work reliably. This does _not_ address potential issues with dropped PNG diffs (i.e. the lack of keyframes in ipympl) but it does address the major rendering issues in current `master` whereby `draw()` was sometimes being called from more than one thread.