### PR TITLE
Avoid pulling the entire array into memory.

### DIFF
--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -379,7 +379,7 @@ class Images:
         run = event.run
         func = functools.partial(self._transform, field=self.field)
         image = ImageSpec(func, run, label=self.field)
-        array_shape = run.primary.read()[self.field].shape
+        array_shape = run.primary.to_dask()[self.field].shape
         self._run_manager.track_artist(image)
         self.axes.images.append(image)
         self.axes.title = self._label_maker(run, self.field)

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -379,19 +379,9 @@ class Images:
         run = event.run
         func = functools.partial(self._transform, field=self.field)
         image = ImageSpec(func, run, label=self.field)
-        array_shape = run.primary.to_dask()[self.field].shape
         self._run_manager.track_artist(image)
         self.axes.images.append(image)
         self.axes.title = self._label_maker(run, self.field)
-        # By default, pixels center on integer coordinates ranging from 0 to
-        # columns-1 horizontally and 0 to rows-1 vertically.
-        # In order to see entire pixels, we set lower limits to -0.5
-        # and upper limits to columns-0.5 horizontally and rows-0.5 vertically
-        # if limits aren't specifically set.
-        if self.axes.x_limits is None:
-            self.axes.x_limits = (-0.5, array_shape[-1] - 0.5)
-        if self.axes.y_limits is None:
-            self.axes.y_limits = (-0.5, array_shape[-2] - 0.5)
         # TODO Set axes x, y from xarray dims
 
     def _transform(self, run, field):

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -385,9 +385,7 @@ class Images:
         # TODO Set axes x, y from xarray dims
 
     def _transform(self, run, field):
-        (data,) = numpy.asarray(
-            call_or_eval((field,), run, self.needs_streams, self.namespace)
-        )
+        (data,) = call_or_eval((field,), run, self.needs_streams, self.namespace)
         # If the data is more than 2D, take the middle slice from the leading
         # axis until there are only two axes.
         while data.ndim > 2:


### PR DESCRIPTION
[Edit:]

There were two aspects to this.

1. Use `to_dask()` instead of `read()`.
2. Avoid calling `numpy.asarray(...)` (which forces a dask array into memory) on the full array before we subselect the slice we actually need to read and visualize.

Fixing one required another change, not directly related, explained in the comment below.