### PR TITLE
Refactor Model <---> View-model contract

### DIFF
--- a/bluesky_widgets/_matplotlib_axes.py
+++ b/bluesky_widgets/_matplotlib_axes.py
@@ -1,16 +1,16 @@
 """
-This joins our AxesSpec model to matplotlib.axes.Axes. It is used by
+This joins our Axes model to matplotlib.axes.Axes. It is used by
 bluesky_widgets.qt.figures and bluesky_widgets.jupyter.figures.
 """
 import logging
 
-from .models.plot_specs import AxesSpec, LineSpec, ImageSpec
+from .models.plot_specs import Axes, Line, Image
 from .models.utils import run_is_live_and_not_completed
 
 
 class MatplotlibAxes:
     """
-    Respond to changes in AxesSpec by manipulating matplotlib.axes.Axes.
+    Respond to changes in Axes by manipulating matplotlib.axes.Axes.
 
     Note that while most view classes accept model as their only __init__
     parameter, this view class expects matplotlib.axes.Axes as well. If we
@@ -24,7 +24,7 @@ class MatplotlibAxes:
     receives pre-made Axes from the outside, ultimately via plt.subplots(...).
     """
 
-    def __init__(self, model: AxesSpec, axes, *args, **kwargs):
+    def __init__(self, model: Axes, axes, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model = model
         self.axes = axes
@@ -47,7 +47,7 @@ class MatplotlibAxes:
             axes.set_ylim(model.y_limits)
 
         # Use matplotlib's user-configurable ID so that we can look up the
-        # AxesSpec from the axes if we need to.
+        # Axes from the axes if we need to.
         axes.set_gid(model.uuid)
 
         # Keep a reference to all types of artist here.
@@ -57,8 +57,8 @@ class MatplotlibAxes:
         self._images = {}
 
         self.type_map = {
-            LineSpec: self._lines,
-            ImageSpec: self._images,
+            Line: self._lines,
+            Image: self._images,
         }
 
         for line_spec in model.lines:

--- a/bluesky_widgets/_matplotlib_axes.py
+++ b/bluesky_widgets/_matplotlib_axes.py
@@ -7,9 +7,6 @@ import logging
 from .models.plot_specs import Axes, Line, Image
 
 
-_VAR_ARGS = object()  # sentinel in translation dict
-
-
 class MatplotlibAxes:
     """
     Respond to changes in Axes by manipulating matplotlib.axes.Axes.
@@ -31,8 +28,6 @@ class MatplotlibAxes:
         self.model = model
         self.axes = axes
 
-        # AxesImage *requires* Axes ax, so we define this mapping as an
-        # instance attribute that can wrap self.axes.
         self.type_map = {
             Line: self._construct_line,
             Image: self._construct_image,

--- a/bluesky_widgets/_matplotlib_axes.py
+++ b/bluesky_widgets/_matplotlib_axes.py
@@ -187,10 +187,12 @@ class MatplotlibAxes:
             **translated_kwargs,
             **artist_spec.style
         )
+        import threading; print('add artist', threading.current_thread().name)
 
         if artist_spec.live:
 
             def update(event):
+                import threading; print('update', threading.current_thread().name)
                 translated_args, translated_kwargs = self._translate(artist_spec, translation)
                 artist.set(**translated_kwargs)
                 self.axes.relim()  # Recompute data limits.
@@ -231,7 +233,7 @@ class MatplotlibAxes:
         artist = self._artists.pop(artist_spec.uuid)
         # Remove it from the canvas.
         artist.remove()
-        print('removed')
+        import threading; print('remove artist', threading.current_thread().name)
         self._update_and_draw()
 
     def _update_and_draw(self):

--- a/bluesky_widgets/conftest.py
+++ b/bluesky_widgets/conftest.py
@@ -36,26 +36,52 @@ def pytest_collection_modifyitems(session, config, items):
             if hasattr(item, "callspec") and "FigureView" in item.callspec.params:
                 if item.callspec.params["FigureView"] is QtFigure:
                     item.fixturenames.append("qtbot")
+            elif hasattr(item, "callspec") and "FigureViews" in item.callspec.params:
+                if item.callspec.params["FigureViews"] is QtFigures:
+                    item.fixturenames.append("qtbot")
 
 
-_figure_views = []
+_figure_view_params = []
 if importlib.util.find_spec("qtpy"):
 
     from bluesky_widgets.qt.figures import QtFigure
 
-    _figure_views.append(QtFigure)
+    _figure_view_params.append(QtFigure)
 if importlib.util.find_spec("ipywidgets"):
 
     from bluesky_widgets.jupyter.figures import JupyterFigure
 
-    _figure_views.append(JupyterFigure)
+    _figure_view_params.append(JupyterFigure)
 if importlib.util.find_spec("matplotlib"):
 
     from bluesky_widgets.headless.figures import HeadlessFigure
 
-    _figure_views.append(HeadlessFigure)
+    _figure_view_params.append(HeadlessFigure)
 
 
-@pytest.fixture(params=_figure_views)
+@pytest.fixture(params=_figure_view_params)
 def FigureView(request):
+    return request.param
+
+
+_figure_views_params = []
+if importlib.util.find_spec("qtpy"):
+
+    from bluesky_widgets.qt.figures import QtFigures
+
+    _figure_views_params.append(QtFigures)
+if importlib.util.find_spec("ipywidgets"):
+
+    from bluesky_widgets.jupyter.figures import JupyterFigures
+
+    _figure_views_params.append(JupyterFigures)
+if importlib.util.find_spec("matplotlib"):
+
+    from bluesky_widgets.headless.figures import HeadlessFigures
+
+    _figure_views_params.append(HeadlessFigures)
+
+
+@pytest.fixture(params=_figure_views_params)
+def FigureViews(request):
     return request.param

--- a/bluesky_widgets/headless/_tests/test_closing.py
+++ b/bluesky_widgets/headless/_tests/test_closing.py
@@ -1,13 +1,13 @@
 import matplotlib.pyplot as plt
 
 
-from ...models.plot_specs import FigureSpec, AxesSpec
+from ...models.plot_specs import Figure, Axes
 from ..figures import HeadlessFigure
 
 
 def test_closing():
-    axes = AxesSpec()
-    model = FigureSpec(axes=(axes,), title="test")
+    axes = Axes()
+    model = Figure(axes=(axes,), title="test")
     view = HeadlessFigure(model)
     assert plt.fignum_exists(view.figure.number)
     view.close_figure()

--- a/bluesky_widgets/headless/figures.py
+++ b/bluesky_widgets/headless/figures.py
@@ -2,14 +2,14 @@ import collections.abc
 from pathlib import Path
 import matplotlib
 
-from ..models.plot_specs import FigureSpec, FigureSpecList
+from ..models.plot_specs import Figure, FigureList
 from .._matplotlib_axes import MatplotlibAxes
 from ..utils.dict_view import DictView
 
 
 class HeadlessFigures:
     """
-    A headless "view" for a FigureSpecList model.
+    A headless "view" for a FigureList model.
 
     It does not produce a graphical user interface. Instead, it provides
     methods for exporting figures as images.
@@ -30,7 +30,7 @@ class HeadlessFigures:
     >>> headless.export_all("path/to/directory/", format="jpg")
     """
 
-    def __init__(self, model: FigureSpecList):
+    def __init__(self, model: FigureList):
 
         self.model = model
         # Map Figure UUID to widget with HeadlessFigure
@@ -43,7 +43,7 @@ class HeadlessFigures:
 
     @property
     def figures(self):
-        "Read-only access to the mapping FigureSpec UUID -> HeadlessFigure"
+        "Read-only access to the mapping Figure UUID -> HeadlessFigure"
         return DictView(self._figures)
 
     def _on_figure_added(self, event):
@@ -105,7 +105,7 @@ class HeadlessFigures:
 
 class HeadlessFigure:
     """
-    A Headless "view" for a FigureSpec model. This always contains one Figure.
+    A Headless "view" for a Figure model. This always contains one Figure.
 
     Examples
     --------
@@ -116,7 +116,7 @@ class HeadlessFigure:
     >>> headless.export("my-figure.png")
     """
 
-    def __init__(self, model: FigureSpec):
+    def __init__(self, model: Figure):
         self.model = model
         self.figure, self.axes_list = _make_figure(model)
         self.figure.suptitle(model.title)
@@ -125,12 +125,12 @@ class HeadlessFigure:
             self._axes[axes_spec.uuid] = MatplotlibAxes(model=axes_spec, axes=axes)
 
         model.events.title.connect(self._on_title_changed)
-        # The FigureSpec model does not currently allow axes to be added or
+        # The Figure model does not currently allow axes to be added or
         # removed, so we do not need to handle changes in model.axes.
 
     @property
     def axes(self):
-        "Read-only access to the mapping AxesSpec UUID -> MatplotlibAxes"
+        "Read-only access to the mapping Axes UUID -> MatplotlibAxes"
         return DictView(self._axes)
 
     def _on_title_changed(self, event):
@@ -161,7 +161,7 @@ def _make_figure(figure_spec):
     matplotlib.use("Agg")  # must set before importing matplotlib.pyplot
     import matplotlib.pyplot as plt  # noqa
 
-    # TODO Let FigureSpec give different options to subplots here,
+    # TODO Let Figure give different options to subplots here,
     # but verify that number of axes created matches the number of axes
     # specified.
     fig, axes = plt.subplots(len(figure_spec.axes))

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -2,7 +2,7 @@ import collections.abc
 
 from ipywidgets import widgets
 
-from ..models.plot_specs import FigureSpec, FigureSpecList
+from ..models.plot_specs import Figure, FigureList
 from .._matplotlib_axes import MatplotlibAxes
 from ..utils.dict_view import DictView
 
@@ -21,10 +21,10 @@ def _initialize_mpl():
 
 class JupyterFigures(widgets.Tab):
     """
-    A Jupyter (ipywidgets) view for a FigureSpecList model.
+    A Jupyter (ipywidgets) view for a FigureList model.
     """
 
-    def __init__(self, model: FigureSpecList, *args, **kwargs):
+    def __init__(self, model: FigureList, *args, **kwargs):
         _initialize_mpl()
         super().__init__(*args, **kwargs)
         self.model = model
@@ -38,7 +38,7 @@ class JupyterFigures(widgets.Tab):
 
     @property
     def figures(self):
-        "Read-only access to the mapping FigureSpec UUID -> JupyterFigure"
+        "Read-only access to the mapping Figure UUID -> JupyterFigure"
         return DictView(self._figures)
 
     def _on_figure_added(self, event):
@@ -96,10 +96,10 @@ class JupyterFigures(widgets.Tab):
 
 class JupyterFigure(widgets.HBox):
     """
-    A Jupyter view for a FigureSpec model. This always contains one Figure.
+    A Jupyter view for a Figure model. This always contains one Figure.
     """
 
-    def __init__(self, model: FigureSpec):
+    def __init__(self, model: Figure):
         _initialize_mpl()
         super().__init__()
         self.model = model
@@ -121,12 +121,12 @@ class JupyterFigure(widgets.HBox):
         self.figure.canvas.manager.resize(width, height)
         self.figure.canvas.draw_idle()
 
-        # The FigureSpec model does not currently allow axes to be added or
+        # The Figure model does not currently allow axes to be added or
         # removed, so we do not need to handle changes in model.axes.
 
     @property
     def axes(self):
-        "Read-only access to the mapping AxesSpec UUID -> MatplotlibAxes"
+        "Read-only access to the mapping Axes UUID -> MatplotlibAxes"
         return DictView(self._axes)
 
     def _on_title_changed(self, event):
@@ -148,7 +148,7 @@ class _JupyterFigureTab(widgets.HBox):
     This is aware of its parent in order to support tab-closing.
     """
 
-    def __init__(self, model: FigureSpec, parent):
+    def __init__(self, model: Figure, parent):
         super().__init__()
         self.model = model
         self.parent = parent
@@ -167,7 +167,7 @@ class _JupyterFigureTab(widgets.HBox):
 
     @property
     def axes(self):
-        "Read-only access to the mapping AxesSpec UUID -> MatplotlibAxes"
+        "Read-only access to the mapping Axes UUID -> MatplotlibAxes"
         return DictView(self._jupyter_figure.axes)
 
 
@@ -183,7 +183,7 @@ def _make_figure(figure_spec):
     # only want to see the figures where they are placed explicitly in widgets.
     plt.ioff()
 
-    # TODO Let FigureSpec give different options to subplots here,
+    # TODO Let Figure give different options to subplots here,
     # but verify that number of axes created matches the number of axes
     # specified.
     figure, axes = plt.subplots(len(figure_spec.axes))

--- a/bluesky_widgets/models/_tests/test_figures.py
+++ b/bluesky_widgets/models/_tests/test_figures.py
@@ -79,7 +79,7 @@ def test_short_title_syncing(FigureViews, request):
     assert view.tabText(0) == expected_title
 
 
-def test_non_null_short_title_syncing(FigureViews):
+def test_non_null_short_title_syncing(FigureViews, request):
     QtFigures = pytest.importorskip("bluesky_widgets.qt.figures.QtFigures")
     if request.getfixturevalue("FigureViews") is not QtFigures:
         pytest.skip("This tests details of the QtFigures view.")
@@ -122,7 +122,7 @@ def test_axes_set_figure():
 
 
 artist_set_axes_params = pytest.mark.parametrize(
-    'artist_factory',
+    "artist_factory",
     # These are factories because each artist can only be assigned to Axes once
     # in its lifecycle. For each test that these params are used in, we need a
     # fresh instance.
@@ -147,7 +147,7 @@ def test_artist_set_axes_at_init(artist_factory):
     with pytest.raises(CallbackException) as exc_info:
         Axes(artists=[artist])
     exc = exc_info.value
-    assert hasattr(exc, '__cause__') and isinstance(exc.__cause__, AxesAlreadySet)
+    assert hasattr(exc, "__cause__") and isinstance(exc.__cause__, AxesAlreadySet)
 
 
 @artist_set_axes_params
@@ -164,4 +164,4 @@ def test_artist_set_axes_after_init(artist_factory):
     with pytest.raises(CallbackException) as exc_info:
         Axes(artists=[artist])
     exc = exc_info.value
-    assert hasattr(exc, '__cause__') and isinstance(exc.__cause__, AxesAlreadySet)
+    assert hasattr(exc, "__cause__") and isinstance(exc.__cause__, AxesAlreadySet)

--- a/bluesky_widgets/models/_tests/test_figures.py
+++ b/bluesky_widgets/models/_tests/test_figures.py
@@ -1,14 +1,15 @@
 from bluesky_live.run_builder import RunBuilder
+from bluesky_live.event import CallbackException
 import pytest
 
 from ...models.plot_specs import (
+    AxesAlreadySet,
     Figure,
     FigureList,
     Axes,
     Line,
     Image,
 )
-from ..figures import QtFigure, QtFigures
 
 
 # Generate example data.
@@ -19,33 +20,33 @@ run = builder.get_run()
 
 def transform(run):
     ds = run.primary.read()
-    return ds["a"], ds["b"]
+    return {"x": ds["a"], "y": ds["b"]}
 
 
 def func(run):
-    line = Line(transform, run, "label")
-    axes = Axes(lines=[line], x_label="a", y_label="b", title="axes title")
+    line = Line.from_run(transform, run, "label")
+    axes = Axes(artists=[line], x_label="a", y_label="b", title="axes title")
     figure = Figure((axes,), title="figure title")
     return figure
 
 
-def test_figure(qtbot):
-    "Basic test: create a QtFigure."
+def test_figure(FigureView):
+    "Basic test: create a FigureView."
     figure = func(run)
-    QtFigure(figure)
+    FigureView(figure)
 
 
-def test_figures(qtbot):
-    "Basic test: create QtFigures."
+def test_figures(FigureViews):
+    "Basic test: create FigureViews."
     figure = func(run)
     another_figure = func(run)
     figures = FigureList([figure, another_figure])
-    QtFigures(figures)
+    FigureViews(figures)
 
 
-def test_figure_title_syncing(qtbot):
+def test_figure_title_syncing(FigureView):
     model = func(run)
-    view = QtFigure(model)
+    view = FigureView(model)
     initial = model.title
     assert view.figure._suptitle.get_text() == initial
     expected = "figure title changed"
@@ -56,10 +57,13 @@ def test_figure_title_syncing(qtbot):
     assert view.figure._suptitle.get_text() == expected
 
 
-def test_short_title_syncing(qtbot):
+def test_short_title_syncing(FigureViews, request):
+    QtFigures = pytest.importorskip("bluesky_widgets.qt.figures.QtFigures")
+    if request.getfixturevalue("FigureViews") is not QtFigures:
+        pytest.skip("This tests details of the QtFigures view.")
     model = func(run)
     figures = FigureList([model])
-    view = QtFigures(figures)
+    view = FigureViews(figures)
     actual_title = view.figures[model.uuid].figure._suptitle.get_text()
     assert view.tabText(0) == actual_title
     expected_short_title = "new short title"
@@ -75,11 +79,14 @@ def test_short_title_syncing(qtbot):
     assert view.tabText(0) == expected_title
 
 
-def test_non_null_short_title_syncing(qtbot):
+def test_non_null_short_title_syncing(FigureViews):
+    QtFigures = pytest.importorskip("bluesky_widgets.qt.figures.QtFigures")
+    if request.getfixturevalue("FigureViews") is not QtFigures:
+        pytest.skip("This tests details of the QtFigures view.")
     model = func(run)
     model.short_title = "short title"
     figures = FigureList([model])
-    view = QtFigures(figures)
+    view = FigureViews(figures)
     actual_title = view.figures[model.uuid].figure._suptitle.get_text()
     assert view.tabText(0) == model.short_title
     assert actual_title == model.title
@@ -89,9 +96,9 @@ def test_non_null_short_title_syncing(qtbot):
     ("model_property", "mpl_method"),
     [("title", "get_title"), ("x_label", "get_xlabel"), ("y_label", "get_ylabel")],
 )
-def test_axes_syncing(qtbot, model_property, mpl_method):
+def test_axes_syncing(FigureView, model_property, mpl_method):
     model = func(run)
-    view = QtFigure(model)
+    view = FigureView(model)
     initial = getattr(model.axes[0], model_property)
     assert getattr(view.figure.axes[0], mpl_method)() == initial
     expected = "axes title changed"
@@ -115,39 +122,46 @@ def test_axes_set_figure():
 
 
 artist_set_axes_params = pytest.mark.parametrize(
-    ("model_property", "artist_factory"),
+    'artist_factory',
+    # These are factories because each artist can only be assigned to Axes once
+    # in its lifecycle. For each test that these params are used in, we need a
+    # fresh instance.
     [
-        ("lines", lambda: Line(transform, run, "label")),
-        ("images", lambda: Image(transform, run, "label")),
+        lambda: Line.from_run(transform, run, "label"),
+        lambda: Image.from_run(transform, run, "label"),
     ],
     ids=["lines", "images"],
 )
 
 
 @artist_set_axes_params
-def test_artist_set_axes_at_init(model_property, artist_factory):
+def test_artist_set_axes_at_init(artist_factory):
     "Adding an artist to axes at init time sets its axes."
     artist = artist_factory()
-    axes = Axes(**{model_property: [artist]})
-    assert artist in getattr(axes, model_property)
+    axes = Axes(artists=[artist])
+    assert artist in axes.artists
     assert artist in axes.by_uuid.values()
     assert artist.axes is axes
 
     # Once line belong to a axes, it cannot belong to another axes.
-    with pytest.raises(RuntimeError):
-        Axes(**{model_property: [artist]})
+    with pytest.raises(CallbackException) as exc_info:
+        Axes(artists=[artist])
+    exc = exc_info.value
+    assert hasattr(exc, '__cause__') and isinstance(exc.__cause__, AxesAlreadySet)
 
 
 @artist_set_axes_params
-def test_artist_set_axes_after_init(model_property, artist_factory):
+def test_artist_set_axes_after_init(artist_factory):
     "Adding an artist to axes after init time sets its axes."
     artist = artist_factory()
     axes = Axes()
-    getattr(axes, model_property).append(artist)
-    assert artist in getattr(axes, model_property)
+    axes.artists.append(artist)
+    assert artist in axes.artists
     assert artist in axes.by_uuid.values()
     assert artist.axes is axes
 
     # Once line belong to a axes, it cannot belong to another axes.
-    with pytest.raises(RuntimeError):
-        Axes(**{model_property: [artist]})
+    with pytest.raises(CallbackException) as exc_info:
+        Axes(artists=[artist])
+    exc = exc_info.value
+    assert hasattr(exc, '__cause__') and isinstance(exc.__cause__, AxesAlreadySet)

--- a/bluesky_widgets/models/_tests/test_image.py
+++ b/bluesky_widgets/models/_tests/test_image.py
@@ -2,7 +2,7 @@ from bluesky_live.run_builder import build_simple_run
 import numpy
 
 from ..plot_builders import Images
-from ..plot_specs import AxesSpec, FigureSpec
+from ..plot_specs import Axes, Figure
 
 
 def test_image(FigureView):
@@ -41,10 +41,10 @@ def test_properties(FigureView):
 
 
 def test_figure_set_after_instantiation(FigureView):
-    axes = AxesSpec()
+    axes = Axes()
     model = Images("ccd", axes=axes)
     assert model.figure is None
-    figure = FigureSpec((axes,), title="")
+    figure = Figure((axes,), title="")
     assert model.figure is figure
     view = FigureView(model.figure)
     view.close()

--- a/bluesky_widgets/models/_tests/test_image.py
+++ b/bluesky_widgets/models/_tests/test_image.py
@@ -10,9 +10,9 @@ def test_image(FigureView):
     run = build_simple_run({"ccd": numpy.random.random((11, 13))})
     model = Images("ccd")
     view = FigureView(model.figure)
-    assert not model.figure.axes[0].images
+    assert not model.figure.axes[0].artists
     model.add_run(run)
-    assert model.figure.axes[0].images
+    assert model.figure.axes[0].artists
     view.close()
 
 

--- a/bluesky_widgets/models/_tests/test_lines.py
+++ b/bluesky_widgets/models/_tests/test_lines.py
@@ -36,14 +36,14 @@ def test_pinned(FigureView):
     for run in runs[6:]:
         model.add_run(run)
         assert len(model.runs) == 1 + MAX_RUNS
-        assert len(model.figure.axes[0].lines) == num_ys * (1 + MAX_RUNS)
+        assert len(model.figure.axes[0].artists) == num_ys * (1 + MAX_RUNS)
     # Check that it hasn't been bumped off.
     assert pinned_run in model.runs
 
     # Remove the pinned run.
     model.discard_run(pinned_run)
     assert len(model.runs) == MAX_RUNS
-    assert len(model.figure.axes[0].lines) == num_ys * MAX_RUNS
+    assert len(model.figure.axes[0].artists) == num_ys * MAX_RUNS
     assert pinned_run not in model.runs
 
     view.close()
@@ -73,11 +73,11 @@ def test_decrease_max_runs(FigureView):
     for run in runs[:5]:
         model.add_run(run)
     assert len(model.runs) == INITIAL_MAX_RUNS
-    assert len(model.figure.axes[0].lines) == INITIAL_MAX_RUNS
+    assert len(model.figure.axes[0].artists) == INITIAL_MAX_RUNS
     # Decrease max_runs.
     model.max_runs = MAX_RUNS
     assert len(model.runs) == MAX_RUNS
-    assert len(model.figure.axes[0].lines) == MAX_RUNS
+    assert len(model.figure.axes[0].artists) == MAX_RUNS
 
     view.close()
 
@@ -89,7 +89,7 @@ def test_expressions(expr, FigureView):
     model = Lines("motor", ys, max_runs=MAX_RUNS)
     view = FigureView(model.figure)
     model.add_run(runs[0])
-    assert len(model.figure.axes[0].lines) == 1
+    assert len(model.figure.axes[0].artists) == 1
 
     view.close()
 
@@ -109,7 +109,7 @@ def test_functions(func, FigureView):
     model = Lines("motor", ys, max_runs=MAX_RUNS)
     view = FigureView(model.figure)
     model.add_run(runs[0])
-    assert len(model.figure.axes[0].lines) == 1
+    assert len(model.figure.axes[0].artists) == 1
 
     view.close()
 

--- a/bluesky_widgets/models/_tests/test_lines.py
+++ b/bluesky_widgets/models/_tests/test_lines.py
@@ -2,7 +2,7 @@ from bluesky_live.run_builder import build_simple_run
 import pytest
 
 from ..plot_builders import Lines
-from ..plot_specs import AxesSpec, FigureSpec
+from ..plot_specs import Axes, Figure
 
 
 # Make some runs to use.
@@ -115,10 +115,10 @@ def test_functions(func, FigureView):
 
 
 def test_figure_set_after_instantiation(FigureView):
-    axes = AxesSpec()
+    axes = Axes()
     model = Lines("motor", [], axes=axes)
     assert model.figure is None
-    figure = FigureSpec((axes,), title="")
+    figure = Figure((axes,), title="")
     assert model.figure is figure
     view = FigureView(model.figure)
     view.close()

--- a/bluesky_widgets/models/_tests/test_rastered_image.py
+++ b/bluesky_widgets/models/_tests/test_rastered_image.py
@@ -3,7 +3,7 @@ import pytest
 import numpy
 
 from ..plot_builders import RasteredImages
-from ..plot_specs import AxesSpec, FigureSpec
+from ..plot_specs import Axes, Figure
 
 
 @pytest.fixture
@@ -61,8 +61,8 @@ def test_x_y_positive_change_x_y_limits(non_snaking_run, FigureView):
 def test_x_y_limits_change_x_y_positive(non_snaking_run, FigureView):
     "Test x_limits and y_limits change x_positive and y_positive"
     run = non_snaking_run
-    axes = AxesSpec(x_limits=(1.5, -0.5), y_limits=(1.5, -0.5))
-    FigureSpec((axes,), title="")
+    axes = Axes(x_limits=(1.5, -0.5), y_limits=(1.5, -0.5))
+    Figure((axes,), title="")
     model = RasteredImages("ccd", shape=(2, 2), axes=axes)
     view = FigureView(model.figure)
     model.add_run(run)
@@ -179,8 +179,8 @@ def test_snaking_image_data_positions(FigureView):
 
 
 def test_figure_set_after_instantiation():
-    axes = AxesSpec()
+    axes = Axes()
     model = RasteredImages("ccd", shape=(2, 2), axes=axes)
     assert model.figure is None
-    figure = FigureSpec((axes,), title="")
+    figure = Figure((axes,), title="")
     assert model.figure is figure

--- a/bluesky_widgets/models/_tests/test_rastered_image.py
+++ b/bluesky_widgets/models/_tests/test_rastered_image.py
@@ -35,9 +35,9 @@ def test_rastered_image(non_snaking_run, FigureView):
     run = non_snaking_run
     model = RasteredImages("ccd", shape=(2, 2))
     view = FigureView(model.figure)
-    assert not model.figure.axes[0].images
+    assert not model.figure.axes[0].artists
     model.add_run(run)
-    assert model.figure.axes[0].images
+    assert model.figure.axes[0].artists
     view.close()
 
 
@@ -79,7 +79,7 @@ def test_non_snaking_image_data(non_snaking_run, FigureView):
     model = RasteredImages("ccd", shape=(2, 2))
     model.add_run(run)
     view = FigureView(model.figure)
-    actual_data = model.figure.axes[0].images[0].func(run)
+    actual_data = model.figure.axes[0].artists[0].update()["array"]
     expected_data = [[1, 2], [3, 4]]
     assert numpy.array_equal(actual_data, expected_data)
     view.close()
@@ -90,7 +90,7 @@ def test_snaking_image_data(snaking_run, FigureView):
     model = RasteredImages("ccd", shape=(2, 2))
     view = FigureView(model.figure)
     model.add_run(run)
-    actual_data = model.figure.axes[0].images[0].func(run)
+    actual_data = model.figure.axes[0].artists[0].update()["array"]
     expected_data = [[1, 2], [4, 3]]
     assert numpy.array_equal(actual_data, expected_data)
     view.close()
@@ -110,28 +110,28 @@ def test_non_snaking_image_data_positions(FigureView):
         builder.add_stream(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, numpy.nan], [numpy.nan, numpy.nan]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Second point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [numpy.nan, numpy.nan]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Third point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [3, numpy.nan]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Fourth point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [3, 4]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
     view.close()
@@ -151,28 +151,28 @@ def test_snaking_image_data_positions(FigureView):
         builder.add_stream(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, numpy.nan], [numpy.nan, numpy.nan]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Second point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [numpy.nan, numpy.nan]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Third point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [numpy.nan, 3]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
         # Fourth point
         builder.add_data(
             "primary", data={"ccd": [next(ccd)], "x": [next(x)], "y": [next(y)]}
         )
-        actual_data = model.figure.axes[0].images[0].func(run)
+        actual_data = model.figure.axes[0].artists[0].update()["array"]
         expected_data = [[1, 2], [4, 3]]
         assert numpy.array_equal(actual_data, expected_data, equal_nan=True)
     view.close()

--- a/bluesky_widgets/models/auto_plot_builders/_base.py
+++ b/bluesky_widgets/models/auto_plot_builders/_base.py
@@ -1,6 +1,6 @@
 import abc
 
-from ..plot_specs import FigureSpecList
+from ..plot_specs import FigureList
 from ..utils import run_is_live_and_not_completed
 
 
@@ -18,7 +18,7 @@ class AutoPlotter(abc.ABC):
     """
 
     def __init__(self):
-        self.figures = FigureSpecList()
+        self.figures = FigureList()
         self.figures.events.removed.connect(self._on_figure_removed)
         self.plot_builders = []
 

--- a/bluesky_widgets/models/auto_plot_builders/_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_lines.py
@@ -1,7 +1,7 @@
 from warnings import warn
 
 from ..plot_builders import Lines
-from ..plot_specs import FigureSpec, AxesSpec
+from ..plot_specs import Figure, Axes
 from .._heuristics import hinted_fields
 from ._base import AutoPlotter
 
@@ -191,7 +191,7 @@ class AutoLines(AutoPlotter):
                             "".format(y_key, dtype)
                         )
                         continue
-                    axes = AxesSpec(x_label=x_key, title=y_key)
+                    axes = Axes(x_label=x_key, title=y_key)
                     axes_list.append(axes)
                     lines_kwargs = {}
                     if self.max_runs is not None:
@@ -214,7 +214,7 @@ class AutoLines(AutoPlotter):
                     short_title = title[:15] + "..."
                 else:
                     short_title = title
-                figure = FigureSpec(axes_list, title=title, short_title=short_title)
+                figure = Figure(axes_list, title=title, short_title=short_title)
                 self._lines_instances[key] = lines_instances
                 self.plot_builders.extend(lines_instances)
                 self.figures.append(figure)

--- a/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_images.py
+++ b/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_images.py
@@ -13,7 +13,7 @@ def test_images():
     assert not model.figures
     model.add_run(run)
     assert len(model.figures) == 1
-    assert model.figures[0].axes[0].images
+    assert model.figures[0].axes[0].artists
     view.close()
 
 
@@ -30,6 +30,6 @@ def test_images_multiple_fields():
     assert not model.figures
     model.add_run(run)
     assert len(model.figures) == 2
-    assert model.figures[0].axes[0].images
-    assert model.figures[1].axes[0].images
+    assert model.figures[0].axes[0].artists
+    assert model.figures[1].axes[0].artists
     view.close()

--- a/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
@@ -40,7 +40,7 @@ def test_pinned():
         model.add_run(run)
         assert len(model.plot_builders[0].runs) == 1 + MAX_RUNS
         for axes_index in range(NUM_YS):
-            assert len(model.figures[0].axes[axes_index].lines) == (1 + MAX_RUNS)
+            assert len(model.figures[0].axes[axes_index].artists) == (1 + MAX_RUNS)
     # Check that it hasn't been bumped off.
     assert pinned_run in model.plot_builders[0].runs
     assert len(model.figures) == 1
@@ -49,7 +49,7 @@ def test_pinned():
     model.discard_run(pinned_run)
     assert len(model.plot_builders[0].runs) == MAX_RUNS
     for axes_index in range(NUM_YS):
-        assert len(model.figures[0].axes[axes_index].lines) == MAX_RUNS
+        assert len(model.figures[0].axes[axes_index].artists) == MAX_RUNS
     assert pinned_run not in model.plot_builders[0].runs
 
     view.close()
@@ -63,10 +63,10 @@ def test_decrease_max_runs():
     for run in runs[:5]:
         model.add_run(run)
     assert len(model.plot_builders[0].runs) == INITIAL_MAX_RUNS
-    assert len(model.figures[0].axes[0].lines) == INITIAL_MAX_RUNS
+    assert len(model.figures[0].axes[0].artists) == INITIAL_MAX_RUNS
     # Decrease max_runs.
     model.max_runs = MAX_RUNS
     assert len(model.plot_builders[0].runs) == MAX_RUNS
-    assert len(model.figures[0].axes[0].lines) == MAX_RUNS
+    assert len(model.figures[0].axes[0].artists) == MAX_RUNS
 
     view.close()

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -4,10 +4,10 @@ import itertools
 import numpy
 
 from .plot_specs import (
-    FigureSpec,
-    AxesSpec,
-    ImageSpec,
-    LineSpec,
+    Figure,
+    Axes,
+    Image,
+    Line,
 )
 from .utils import auto_label, call_or_eval, RunManager, run_is_live_and_not_completed
 from ..utils.dict_view import DictView
@@ -59,7 +59,7 @@ class Lines:
         Streams referred to by x and y. Default is ``["primary"]``
     namespace : Dict, optional
         Inject additional tokens to be used in expressions for x and y
-    axes : AxesSpec, optional
+    axes : Axes, optional
         If None, an axes and figure are created with default labels and titles
         derived from the ``x`` and ``y`` parameters.
 
@@ -75,8 +75,8 @@ class Lines:
         last (first in, first out) so that there are at most ``max_runs``.
     pinned : Frozenset[String]
         Run uids of pinned runs.
-    figure : FigureSpec
-    axes : AxesSpec
+    figure : Figure
+    axes : Axes
     x : String | Callable
         Read-only access to x
     ys : Tuple[String | Callable]
@@ -177,11 +177,11 @@ class Lines:
         self._label_maker = label_maker
         self._namespace = namespace
         if axes is None:
-            axes = AxesSpec(
+            axes = Axes(
                 x_label=auto_label(self.x),
                 y_label=", ".join(auto_label(y) for y in self.ys),
             )
-            figure = FigureSpec((axes,), title=f"{axes.y_label} v {axes.x_label}")
+            figure = Figure((axes,), title=f"{axes.y_label} v {axes.x_label}")
         else:
             figure = axes.figure
         self.axes = axes
@@ -230,7 +230,7 @@ class Lines:
                 label += " (pinned)"
 
             func = functools.partial(self._transform, x=self.x, y=y)
-            line = LineSpec(func, run, label, style)
+            line = Line(func, run, label, style)
             self._run_manager.track_artist(line)
             self.axes.lines.append(line)
 
@@ -292,7 +292,7 @@ class Images:
         Streams referred to by field. Default is ``["primary"]``
     namespace : Dict, optional
         Inject additional tokens to be used in expressions for x and y
-    axes : AxesSpec, optional
+    axes : Axes, optional
         If None, an axes and figure are created with default labels and titles
         derived from the ``x`` and ``y`` parameters.
 
@@ -308,8 +308,8 @@ class Images:
         last (first in, first out) so that there are at most ``max_runs``.
     pinned : Frozenset[String]
         Run uids of pinned runs.
-    figure : FigureSpec
-    axes : AxesSpec
+    figure : Figure
+    axes : Axes
     field : String
         Read-only access to field or expression
     needs_streams : List[String], optional
@@ -354,8 +354,8 @@ class Images:
         self._label_maker = label_maker
         self._namespace = namespace
         if axes is None:
-            axes = AxesSpec()
-            figure = FigureSpec((axes,), title="")
+            axes = Axes()
+            figure = Figure((axes,), title="")
         else:
             figure = axes.figure
         self.axes = axes
@@ -378,7 +378,7 @@ class Images:
     def _add_images(self, event):
         run = event.run
         func = functools.partial(self._transform, field=self.field)
-        image = ImageSpec(func, run, label=self.field)
+        image = Image(func, run, label=self.field)
         self._run_manager.track_artist(image)
         self.axes.images.append(image)
         self.axes.title = self._label_maker(run, self.field)
@@ -444,7 +444,7 @@ class RasteredImages:
         Streams referred to by field. Default is ``["primary"]``
     namespace : Dict, optional
         Inject additional tokens to be used in expressions for x and y
-    axes : AxesSpec, optional
+    axes : Axes, optional
         If None, an axes and figure are created with default labels and titles
         derived from the ``x`` and ``y`` parameters.
     clim : Tuple, optional
@@ -464,8 +464,8 @@ class RasteredImages:
     ----------
     run : BlueskyRun
         The currently-viewed Run
-    figure : FigureSpec
-    axes : AxesSpec
+    figure : Figure
+    axes : Axes
     field : String
         Read-only access to field or expression
     needs_streams : List[String], optional
@@ -519,8 +519,8 @@ class RasteredImages:
         self._run = None
 
         if axes is None:
-            axes = AxesSpec()
-            figure = FigureSpec((axes,), title="")
+            axes = Axes()
+            figure = Figure((axes,), title="")
         else:
             figure = axes.figure
         self.axes = axes
@@ -629,7 +629,7 @@ class RasteredImages:
         run = event.run
         func = functools.partial(self._transform, field=self.field)
         style = {"cmap": self._cmap, "clim": self._clim, "extent": self._extent}
-        image = ImageSpec(func, run, label=self.field, style=style)
+        image = Image(func, run, label=self.field, style=style)
         self._run_manager.track_artist(image)
         md = run.metadata["start"]
         self.axes.images.append(image)

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -204,7 +204,7 @@ class Lines:
         self.discard_run = self._run_manager.discard_run
 
     def _transform(self, run, x, y):
-        return call_or_eval((x, y), run, self.needs_streams, self.namespace)
+        return call_or_eval({"x": x, "y": y}, run, self.needs_streams, self.namespace)
 
     def _add_lines(self, event):
         "Add a line."
@@ -230,9 +230,9 @@ class Lines:
                 label += " (pinned)"
 
             func = functools.partial(self._transform, x=self.x, y=y)
-            line = Line(func, run, label, style)
-            self._run_manager.track_artist(line)
-            self.axes.lines.append(line)
+            line = Line.from_run(func, run, label, style)
+            self._run_manager.track_artist(line, [run])
+            self.axes.artists.append(line)
 
     @property
     def x(self):
@@ -378,20 +378,22 @@ class Images:
     def _add_images(self, event):
         run = event.run
         func = functools.partial(self._transform, field=self.field)
-        image = Image(func, run, label=self.field)
-        self._run_manager.track_artist(image)
-        self.axes.images.append(image)
+        image = Image.from_run(func, run, label=self.field)
+        self._run_manager.track_artist(image, [run])
+        self.axes.artists.append(image)
         self.axes.title = self._label_maker(run, self.field)
         # TODO Set axes x, y from xarray dims
 
     def _transform(self, run, field):
-        (data,) = call_or_eval((field,), run, self.needs_streams, self.namespace)
+        result = call_or_eval({"array": field}, run, self.needs_streams, self.namespace)
         # If the data is more than 2D, take the middle slice from the leading
         # axis until there are only two axes.
+        data = result["array"]
         while data.ndim > 2:
             middle = data.shape[0] // 2
             data = data[middle]
-        return data
+        result["array"] = data
+        return result
 
     @property
     def field(self):
@@ -552,8 +554,9 @@ class RasteredImages:
     @cmap.setter
     def cmap(self, value):
         self._cmap = value
-        for image in self.axes.images:
-            image.style.update({"cmap": value})
+        for artist in self.axes.artists:
+            if isinstance(artist, Image):
+                artist.style.update({"cmap": value})
 
     @property
     def clim(self):
@@ -562,8 +565,9 @@ class RasteredImages:
     @clim.setter
     def clim(self, value):
         self._clim = value
-        for image in self.axes.images:
-            image.style.update({"clim": value})
+        for artist in self.axes.artists:
+            if isinstance(artist, Image):
+                artist.style.update({"clim": value})
 
     @property
     def extent(self):
@@ -572,8 +576,9 @@ class RasteredImages:
     @extent.setter
     def extent(self, value):
         self._extent = value
-        for image in self.axes.images:
-            image.style.update({"extent": value})
+        for artist in self.axes.artist:
+            if isinstance(artist, Image):
+                artist.style.update({"extent": value})
 
     @property
     def x_positive(self):
@@ -629,10 +634,10 @@ class RasteredImages:
         run = event.run
         func = functools.partial(self._transform, field=self.field)
         style = {"cmap": self._cmap, "clim": self._clim, "extent": self._extent}
-        image = Image(func, run, label=self.field, style=style)
-        self._run_manager.track_artist(image)
+        image = Image.from_run(func, run, label=self.field, style=style)
+        self._run_manager.track_artist(image, [run])
         md = run.metadata["start"]
-        self.axes.images.append(image)
+        self.axes.artists.append(image)
         self.axes.title = self._label_maker(run, self.field)
         self.axes.x_label = md["motors"][1]
         self.axes.y_label = md["motors"][0]
@@ -654,9 +659,8 @@ class RasteredImages:
 
     def _transform(self, run, field):
         image_data = numpy.ones(self._shape) * numpy.nan
-        (data,) = numpy.asarray(
-            call_or_eval((field,), run, self.needs_streams, self.namespace)
-        )
+        result = call_or_eval({"data": field}, run, self.needs_streams, self.namespace)
+        data = result["data"]
         snaking = run.metadata["start"]["snaking"]
         for index in range(len(data)):
             pos = list(numpy.unravel_index(index, self._shape))
@@ -664,8 +668,7 @@ class RasteredImages:
                 pos[1] = self._shape[1] - pos[1] - 1
             pos = tuple(pos)
             image_data[pos] = data[index]
-
-        return image_data
+        return {"array": image_data}
 
     @property
     def namespace(self):

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -102,9 +102,8 @@ class Axes(BaseSpec):
 
     Parameters
     ----------
-    lines : List[Line], optional
-    images : List[Image], optional
-    title: String, optional
+    Artists : List[Artist], optional
+    title : String, optional
         Axes title text
     x_label : String, optional
         Text label for x axis
@@ -155,11 +154,8 @@ class Axes(BaseSpec):
     """
 
     __slots__ = (
-        "_type_map",
         "_figure",
         "_artists",
-        "_lines",
-        "_images",
         "_title",
         "_x_label",
         "_y_label",
@@ -171,8 +167,7 @@ class Axes(BaseSpec):
     def __init__(
         self,
         *,
-        lines=None,
-        images=None,
+        artists=None,
         title=None,
         x_label=None,
         y_label=None,
@@ -181,11 +176,9 @@ class Axes(BaseSpec):
         y_limits=None,
         uuid=None,
     ):
+        super().__init__(uuid)
         self._figure = None
-        self._lines = LineList(lines or [])
-        self._images = ImageList(images or [])
-        # A colleciton of all artists, mappping UUID to object
-        self._artists = {}
+        self._artists = ArtistList()
         self._title = title
         self._x_label = x_label
         self._y_label = y_label
@@ -202,19 +195,8 @@ class Axes(BaseSpec):
             x_limits=Event,
             y_limits=Event,
         )
-        super().__init__(uuid)
-        for line in self._lines:
-            self._adopt_artist(line)
-        for image in self._images:
-            self._adopt_artist(image)
-        self._lines.events.added.connect(self._on_artist_added)
-        self._lines.events.removed.connect(self._on_artist_removed)
-        self._images.events.added.connect(self._on_artist_added)
-        self._images.events.removed.connect(self._on_artist_removed)
-        self._type_map = {
-            Line: self._lines,
-            Image: self._images,
-        }
+        self.artists.events.adding.connect(self._on_artist_adding)
+        self.artists.extend(artists or [])
 
     @property
     def figure(self):
@@ -242,14 +224,8 @@ class Axes(BaseSpec):
         self.events.figure(value=figure)
 
     @property
-    def lines(self):
-        "List of Lines on these Axes. Mutable."
-        return self._lines
-
-    @property
-    def images(self):
-        "List of Images on these Axes. Mutable"
-        return self._images
+    def artists(self):
+        return self._artists
 
     @property
     def by_label(self):
@@ -268,7 +244,7 @@ class Axes(BaseSpec):
         >>> spec.style.update(color="red")
         """
         mapping = collections.defaultdict(list)
-        for artist in self._artists.values():
+        for artist in self.artists:
             mapping[artist.label].append(artist)
         return DictView(dict(mapping))
 
@@ -277,19 +253,18 @@ class Axes(BaseSpec):
         """
         Access artists as a read-only dict keyed by uuid.
         """
-        # Return a copy to prohibit mutation of internal bookkeeping.
-        return DictView(self._artists)
+        return DictView({artist.uuid: artist for artist in self.artists})
 
     def discard(self, artist):
         "Discard any Aritst."
         try:
-            self._type_map[type(artist)].remove(artist)
+            self.artists.remove(artist)
         except ValueError:
             pass
 
     def remove(self, artist):
         "Remove any Aritst."
-        self._type_map[type(artist)].remove(artist)
+        self.artists.remove(artist)
 
     @property
     def title(self):
@@ -351,22 +326,17 @@ class Axes(BaseSpec):
         self._y_limits = value
         self.events.y_limits(value=value)
 
-    def _on_artist_added(self, event):
+    def _on_artist_adding(self, event):
+        # This is called when the artist is *about* to be added to self.artists.
+        # Set its axes to self. If it *already* has Axes this will raise and
+        # the Axes will not be added.
         artist = event.item
-        self._adopt_artist(artist)
-
-    def _adopt_artist(self, artist):
         artist.set_axes(self)
-        self._artists[artist.uuid] = artist
-
-    def _on_artist_removed(self, event):
-        artist = event.item
-        del self._artists[artist.uuid]
 
     def __repr__(self):
         return (
-            f"{self.__class__.__name__}(lines={self.lines!r}, "
-            f"images={self.images!r}, title={self.title!r},"
+            f"{self.__class__.__name__}(artists={self.artists!r}, "
+            f"title={self.title!r},"
             f"x_label={self.x_label!r}, y_label={self.y_label!r}, "
             f"aspect={self.aspect!r}, x_limits={self.x_limits!r}, "
             f"y_limits={self.y_limits!r}, uuid={self.uuid!r})"
@@ -377,14 +347,12 @@ class ArtistSpec(BaseSpec):
     """
     Describes the data, computation, and style for an artist (plot element)
 
-    func : callable
+    update : callable
         Expected signature::
 
-            func(run: BlueskyRun)
+            func() -> Dict
 
-        The expected return type varies by artist.
-    run : BlueskyRun
-        Contains data to be visualized.
+        Where Dict contains parameters expected by the specific Artist
     label : String
         Label used in legend and for lookup by label on Axes.
     style : Dict, optional
@@ -393,20 +361,27 @@ class ArtistSpec(BaseSpec):
     axes : Axes, optional
         This may be specified here or set later using :meth:`set_axes`. Once
         specified, it cannot be changed.
+    live : Boolean, optional
+        Listen for future updates.
     uuid : UUID, optional
         Automatically assigned to provide a unique identifier for this Figure,
         used internally to track it.
     """
 
-    __slots__ = ("_func", "_run", "_label", "_style", "_axes")
+    __slots__ = ("_live", "_update", "_label", "_style", "_axes")
 
-    def __init__(self, func, run, label, style=None, axes=None, uuid=None):
-        self._func = func
-        self._run = run
+    def __init__(self, update, *, label, style=None, axes=None, live=True, uuid=None):
+        self._update = update
         self._label = label
         self._style = UpdateOnlyDict(style or {})
         self._axes = axes
-        self.events = EmitterGroup(source=self, label=Event, style_updated=Event)
+        self._live = live
+        self.events = EmitterGroup(
+            source=self,
+            label=Event,
+            new_data=Event,
+            completed=Event,
+            style_updated=Event)
         # Re-emit updates. It's important to re-emit (not just pass through)
         # because the consumer will need access to self.
         self._style.events.updated.connect(
@@ -416,6 +391,55 @@ class ArtistSpec(BaseSpec):
         )
         super().__init__(uuid)
 
+    @property
+    def update(self):
+        return self._update
+
+    @property
+    def live(self):
+        return self._live
+
+    def on_completed(self, event):
+        self._live = False
+
+    @classmethod
+    def from_run(cls, transform, run, label, style=None, axes=None, uuid=None):
+        """
+        Construct a line representing data from one BlueskyRun.
+
+        transform : callable
+            Expected signature::
+
+                func(run: BlueskyRun)
+
+            The expected return type varies by artist.
+        run : BlueskyRun
+            Contains data to be visualized.
+        label : String
+            Label used in legend and for lookup by label on Axes.
+        style : Dict, optional
+            Options passed through to plotting framework, such as ``color`` or
+            ``label``.
+        axes : Axes, optional
+            This may be specified here or set later using :meth:`set_axes`. Once
+            specified, it cannot be changed.
+        uuid : UUID, optional
+            Automatically assigned to provide a unique identifier for this Figure,
+            used internally to track it.
+        """
+        # Isolating bluesky-aware stuff here, including this import.
+        from .utils import run_is_live_and_not_completed
+
+        def update():
+            return transform(run)
+
+        live = run_is_live_and_not_completed(run)
+        line = cls(update, label=label, style=style, live=live)
+        if live:
+            run.events.new_data.connect(line.events.new_data)
+            run.events.completed.connect(line.events.completed)
+        return line
+
     def set_axes(self, axes):
         """
         This is called by Axes when the Artist is added to it.
@@ -423,7 +447,7 @@ class ArtistSpec(BaseSpec):
         It may only be called once.
         """
         if self._axes is not None:
-            raise RuntimeError(
+            raise AxesAlreadySet(
                 f"Axes may only be set once. The artist {self} already belongs "
                 f"to {self.axes} and thus cannot be added to {axes}."
             )
@@ -439,16 +463,6 @@ class ArtistSpec(BaseSpec):
         :meth:`set_axes`
         """
         return self._axes
-
-    @property
-    def func(self):
-        "Function that transforms BlueskyRun to plottble data. Immutable."
-        return self._func
-
-    @property
-    def run(self):
-        "BlueskyRun that is the data source. Immutable."
-        return self._run
 
     @property
     def label(self):
@@ -487,7 +501,7 @@ class ArtistSpec(BaseSpec):
 
     def __repr__(self):
         return (
-            f"{self.__class__.__name__}(func={self.func!r}, run={self.run!r}, "
+            f"{self.__class__.__name__}(update={self.update!r}"
             f"label={self.label!r}, style={self.style!r}, axes={self.axes!r}"
             f"uuid={self.uuid!r})"
         )
@@ -536,9 +550,9 @@ class AxesList(EventedList):
     __slots__ = ()
 
 
-class LineList(EventedList):
+class ArtistList(EventedList):
     __slots__ = ()
 
 
-class ImageList(EventedList):
-    __slots__ = ()
+class AxesAlreadySet(RuntimeError):
+    pass

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -381,7 +381,8 @@ class ArtistSpec(BaseSpec):
             label=Event,
             new_data=Event,
             completed=Event,
-            style_updated=Event)
+            style_updated=Event,
+        )
         # Re-emit updates. It's important to re-emit (not just pass through)
         # because the consumer will need access to self.
         self._style.events.updated.connect(

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -124,27 +124,27 @@ class Axes(BaseSpec):
 
     Note that plot entities like lines may be declared at init time:
 
-    >>> axes = Axes(lines=[Line(...)])
+    >>> axes = Axes(artists=[Line(...)])
 
     Or added later:
 
     >>> axes = Axes()
-    >>> axes.lines.append(Line(...))
+    >>> axes.artists.append(Line(...))
 
     Or a mix:
 
-    >>> axes = Axes(lines=[Line(...)])
-    >>> axes.lines.append(Line(...))
+    >>> axes = Axes(artists=[Line(...)])
+    >>> axes.artists.append(Line(...))
 
     And they can be removed at any point:
 
-    >>> del axes.lines[0]  # Remove the first one.
-    >>> del axes.lines[-1]  # Remove the last one.
-    >>> axes.lines.clear()  # Remove them all.
+    >>> del axes.artists[0]  # Remove the first one.
+    >>> del axes.artists[-1]  # Remove the last one.
+    >>> axes.artists.clear()  # Remove them all.
 
     They may be accessed by type
 
-    >>> axes.lines  # all lines
+    >>> axes.artists  # all artists
     [Line(...), Line(...), ...]
 
     Or by label

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -28,13 +28,13 @@ class BaseSpec:
         return self._uuid
 
 
-class FigureSpec(BaseSpec):
+class Figure(BaseSpec):
     """
     Describes a Figure
 
     Parameters
     ----------
-    axes : Tuple[AxesSpec]
+    axes : Tuple[Axes]
     title : String
         Figure title text
     uuid : UUID, optional
@@ -59,7 +59,7 @@ class FigureSpec(BaseSpec):
     @property
     def axes(self):
         """
-        Tuple of AxesSpecs. Set at FigureSpec creation time and immutable.
+        Tuple of Axess. Set at Figure creation time and immutable.
 
         Why is it immutable? Because rearranging Axes to make room for a new
         one is currently painful to do in matplotlib. This constraint might be
@@ -96,14 +96,14 @@ class FigureSpec(BaseSpec):
         )
 
 
-class AxesSpec(BaseSpec):
+class Axes(BaseSpec):
     """
     Describes a set of Axes
 
     Parameters
     ----------
-    lines : List[LineSpec], optional
-    images : List[ImageSpec], optional
+    lines : List[Line], optional
+    images : List[Image], optional
     title: String, optional
         Axes title text
     x_label : String, optional
@@ -125,17 +125,17 @@ class AxesSpec(BaseSpec):
 
     Note that plot entities like lines may be declared at init time:
 
-    >>> axes = AxesSpec(lines=[LineSpec(...)])
+    >>> axes = Axes(lines=[Line(...)])
 
     Or added later:
 
-    >>> axes = AxesSpec()
-    >>> axes.lines.append(LineSpec(...))
+    >>> axes = Axes()
+    >>> axes.lines.append(Line(...))
 
     Or a mix:
 
-    >>> axes = AxesSpec(lines=[LineSpec(...)])
-    >>> axes.lines.append(LineSpec(...))
+    >>> axes = Axes(lines=[Line(...)])
+    >>> axes.lines.append(Line(...))
 
     And they can be removed at any point:
 
@@ -146,12 +146,12 @@ class AxesSpec(BaseSpec):
     They may be accessed by type
 
     >>> axes.lines  # all lines
-    [LineSpec(...), LineSpec(...), ...]
+    [Line(...), Line(...), ...]
 
     Or by label
 
     >>> axes.by_label["Scan 8"]  # list of all plot entities with this label
-    [LineSpec(...)]  # typically contains just one element
+    [Line(...)]  # typically contains just one element
     """
 
     __slots__ = (
@@ -182,8 +182,8 @@ class AxesSpec(BaseSpec):
         uuid=None,
     ):
         self._figure = None
-        self._lines = LineSpecList(lines or [])
-        self._images = ImageSpecList(images or [])
+        self._lines = LineList(lines or [])
+        self._images = ImageList(images or [])
         # A colleciton of all artists, mappping UUID to object
         self._artists = {}
         self._title = title
@@ -212,8 +212,8 @@ class AxesSpec(BaseSpec):
         self._images.events.added.connect(self._on_artist_added)
         self._images.events.removed.connect(self._on_artist_removed)
         self._type_map = {
-            LineSpec: self._lines,
-            ImageSpec: self._images,
+            Line: self._lines,
+            Image: self._images,
         }
 
     @property
@@ -229,7 +229,7 @@ class AxesSpec(BaseSpec):
 
     def set_figure(self, figure):
         """
-        This is called by FigureSpec when the Axes is added to it.
+        This is called by Figure when the Axes is added to it.
 
         It may only be called once.
         """
@@ -243,12 +243,12 @@ class AxesSpec(BaseSpec):
 
     @property
     def lines(self):
-        "List of LineSpecs on these Axes. Mutable."
+        "List of Lines on these Axes. Mutable."
         return self._lines
 
     @property
     def images(self):
-        "List of ImageSpecs on these Axes. Mutable"
+        "List of Images on these Axes. Mutable"
         return self._images
 
     @property
@@ -386,11 +386,11 @@ class ArtistSpec(BaseSpec):
     run : BlueskyRun
         Contains data to be visualized.
     label : String
-        Label used in legend and for lookup by label on AxesSpec.
+        Label used in legend and for lookup by label on Axes.
     style : Dict, optional
         Options passed through to plotting framework, such as ``color`` or
         ``label``.
-    axes : AxesSpec, optional
+    axes : Axes, optional
         This may be specified here or set later using :meth:`set_axes`. Once
         specified, it cannot be changed.
     uuid : UUID, optional
@@ -418,7 +418,7 @@ class ArtistSpec(BaseSpec):
 
     def set_axes(self, axes):
         """
-        This is called by AxesSpec when the Artist is added to it.
+        This is called by Axes when the Artist is added to it.
 
         It may only be called once.
         """
@@ -452,7 +452,7 @@ class ArtistSpec(BaseSpec):
 
     @property
     def label(self):
-        "Label used in legend and for lookup by label on AxesSpec. Settable."
+        "Label used in legend and for lookup by label on Axes. Settable."
         return self._label
 
     @label.setter
@@ -493,7 +493,7 @@ class ArtistSpec(BaseSpec):
         )
 
 
-class LineSpec(ArtistSpec):
+class Line(ArtistSpec):
     """
     Describes the data, computation, and style for a line
 
@@ -505,11 +505,11 @@ class LineSpec(ArtistSpec):
     run : BlueskyRun
         Contains data to be visualized.
     label : String
-        Label used in legend and for lookup by label on AxesSpec.
+        Label used in legend and for lookup by label on Axes.
     style : Dict, optional
         Options passed through to plotting framework, such as ``color`` or
         ``label``.
-    axes : AxesSpec, optional
+    axes : Axes, optional
         This may be specified here or set later using :meth:`set_axes`. Once
         specified, it cannot be changed.
     uuid : UUID, optional
@@ -520,7 +520,7 @@ class LineSpec(ArtistSpec):
     __slots__ = ()
 
 
-class ImageSpec(ArtistSpec):
+class Image(ArtistSpec):
     "Describes an image (both data and style)"
 
 
@@ -528,17 +528,17 @@ class ImageSpec(ArtistSpec):
 # hence a specific container for each.
 
 
-class FigureSpecList(EventedList):
+class FigureList(EventedList):
     __slots__ = ()
 
 
-class AxesSpecList(EventedList):
+class AxesList(EventedList):
     __slots__ = ()
 
 
-class LineSpecList(EventedList):
+class LineList(EventedList):
     __slots__ = ()
 
 
-class ImageSpecList(EventedList):
+class ImageList(EventedList):
     __slots__ = ()

--- a/bluesky_widgets/qt/_tests/test_qt_viewer_with_search_example.py
+++ b/bluesky_widgets/qt/_tests/test_qt_viewer_with_search_example.py
@@ -33,5 +33,5 @@ def test_app(make_test_app):
     for _, run in catalog.items():
         app.viewer.add_run(run)
     assert app.viewer.figures
-    assert app.viewer.figures[0].axes[0].lines
+    assert app.viewer.figures[0].axes[0].artists
     app.viewer.figures.clear()

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -12,7 +12,7 @@ from matplotlib.backends.backend_qt5agg import (
     NavigationToolbar2QT as NavigationToolbar,
 )
 
-from ..models.plot_specs import FigureSpec, FigureSpecList
+from ..models.plot_specs import Figure, FigureList
 from .._matplotlib_axes import MatplotlibAxes
 from ..utils.event import Event
 from ..utils.dict_view import DictView
@@ -49,12 +49,12 @@ class ThreadsafeMatplotlibAxes(QObject, MatplotlibAxes):
 
 class QtFigures(QTabWidget):
     """
-    A Jupyter (ipywidgets) view for a FigureSpecList model.
+    A Jupyter (ipywidgets) view for a FigureList model.
     """
 
     __callback_event = Signal(object, Event)
 
-    def __init__(self, model: FigureSpecList, parent=None):
+    def __init__(self, model: FigureList, parent=None):
         _initialize_matplotlib()
         super().__init__(parent)
         self.setTabsClosable(True)
@@ -78,7 +78,7 @@ class QtFigures(QTabWidget):
 
     @property
     def figures(self):
-        "Read-only access to the mapping FigureSpec UUID -> QtFigure"
+        "Read-only access to the mapping Figure UUID -> QtFigure"
         return DictView(self._figures)
 
     def _threadsafe_connect(self, emitter, callback):
@@ -150,10 +150,10 @@ class QtFigures(QTabWidget):
 
 class QtFigure(QWidget):
     """
-    A Qt view for a FigureSpec model. This always contains one Figure.
+    A Qt view for a Figure model. This always contains one Figure.
     """
 
-    def __init__(self, model: FigureSpec, parent=None):
+    def __init__(self, model: Figure, parent=None):
         _initialize_matplotlib()
         super().__init__(parent)
         self.model = model
@@ -175,12 +175,12 @@ class QtFigure(QWidget):
         self.setLayout(layout)
 
         model.events.title.connect(self._on_title_changed)
-        # The FigureSpec model does not currently allow axes to be added or
+        # The Figure model does not currently allow axes to be added or
         # removed, so we do not need to handle changes in model.axes.
 
     @property
     def axes(self):
-        "Read-only access to the mapping AxesSpec UUID -> MatplotlibAxes"
+        "Read-only access to the mapping Axes UUID -> MatplotlibAxes"
         return DictView(self._axes)
 
     def _on_title_changed(self, event):
@@ -204,7 +204,7 @@ def _make_figure(figure_spec):
     # for the first time.
     import matplotlib.pyplot as plt
 
-    # TODO Let FigureSpec give different options to subplots here,
+    # TODO Let Figure give different options to subplots here,
     # but verify that number of axes created matches the number of axes
     # specified.
     fig, axes = plt.subplots(len(figure_spec.axes))

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -5,6 +5,7 @@
 
 set -vxeuo pipefail
 
+sudo apt-get update
 sudo apt-get install qt5-default
 
 # These packages are installed in the base environment but may be older

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -31,13 +31,13 @@ Models
 Figures, Axes, and Plot Entities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: bluesky_widgets.models.plot_specs.FigureSpec
+.. autoclass:: bluesky_widgets.models.plot_specs.Figure
    :members:
 
-.. autoclass:: bluesky_widgets.models.plot_specs.AxesSpec
+.. autoclass:: bluesky_widgets.models.plot_specs.Axes
    :members:
 
-.. autoclass:: bluesky_widgets.models.plot_specs.LineSpec
+.. autoclass:: bluesky_widgets.models.plot_specs.Line
    :members:
 
 Base Classes
@@ -82,7 +82,7 @@ Headless
 Plot Builders
 =============
 
-These are models which build a :class:`models.plot_specs.FigureSpec` or a list
+These are models which build a :class:`models.plot_specs.Figure` or a list
 of them. This is an example of a builder that creates one Figure:
 
 .. code:: python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bluesky-live >=0.0.6
+bluesky-live >=0.0.7
 numpy


### PR DESCRIPTION
This is a major refactor and API change of the lower-level entities. It does *not* break any high-level APIs. The user code that I know of will not need any changes to account for this.

## Description

* Bind `Line` and `Image` and in general our `Artist` model to an opaque callable that returns data instead of to a `BlueskyRun`.
* Reduce the API of `Axes`. Instead of keeping separate lists `axes.lines` and `axes.images`, as well as a view of their union, `artists`, just keep one heterogeneous list of `artists` and let the Views sort out what is what based on type. We were already relying on types in various places in the Views. It was not immediately clear to me that this "simplification" was a good one, but I am convinced by the result that it is.
* Rename `FigureSpec` -> `Figure`, `AxesSpec` -> `Axes`, etc. in response to considered feedback. See commit message for details.

## Motivation and Context

* A line should not have a 1:1 correspondence with a `BlueskyRun`. It may represent data aggregated from multiple `BlueskyRun`s. Or, perhaps in the future, from something that isn't a `BlueskyRun` at all.
* This simpler contract between Model and View-model makes it much easier to build new View-models to support new Views. We have near-term plans for a View that uses PIL, a proper napari View (going beyond the demo/example), and a Vega Lite one. This is a good time to refactor the contract to make that easier.

## How Has This Been Tested?

* More test parameterization to test models against all views

<!--
## Screenshots (if appropriate):
-->
