### PR TITLE
Initialize QtFigure with reasonable size.

### DIFF
--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -60,6 +60,7 @@ class QtFigures(QTabWidget):
         super().__init__(parent)
         self.setTabsClosable(True)
         self.tabCloseRequested.connect(self._on_close_tab_requested)
+        self.resize(self.sizeHint())
 
         self.model = model
         # Map Figure UUID to widget with QtFigureTab
@@ -76,6 +77,12 @@ class QtFigures(QTabWidget):
             callback(event)
 
         self.__callback_event.connect(handle_callback)
+
+    def sizeHint(self):
+        size_hint = super().sizeHint()
+        size_hint.setWidth(700)
+        size_hint.setHeight(500)
+        return size_hint
 
     @property
     def figures(self):
@@ -176,10 +183,17 @@ class QtFigure(QWidget):
         layout.addWidget(canvas)
         layout.addWidget(toolbar)
         self.setLayout(layout)
+        self.resize(self.sizeHint())
 
         model.events.title.connect(self._on_title_changed)
         # The Figure model does not currently allow axes to be added or
         # removed, so we do not need to handle changes in model.axes.
+
+    def sizeHint(self):
+        size_hint = super().sizeHint()
+        size_hint.setWidth(700)
+        size_hint.setHeight(500)
+        return size_hint
 
     @property
     def axes(self):

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -2,6 +2,7 @@ import collections.abc
 import gc
 
 from qtpy.QtWidgets import (
+    QSizePolicy,
     QTabWidget,
     QWidget,
     QVBoxLayout,
@@ -166,6 +167,8 @@ class QtFigure(QWidget):
             )
         canvas = FigureCanvas(self.figure)
         canvas.setMinimumWidth(640)
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        canvas.updateGeometry()
         canvas.setParent(self)
         toolbar = NavigationToolbar(canvas, parent=self)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initialize the matplotlib `FigureCanvas` used by`QtFigure` with a reasonable size.

Edit: I based this on https://matplotlib.org/gallery/user_interfaces/embedding_in_qt5_sgskip.html.

## Motivation and Context

@gfabbris shows a situation where the figure window initializes very small, so small it's easy to miss it entirely.

https://github.com/APS-4ID-POLAR/ipython-polar/issues/42#issuecomment-765796787

I have not reproduced this locally, but the video in that comment is a clear demonstration of the issue.

## How Has This Been Tested?

Needs to be evaluated interactively by @gfabbris. Please try it like so:

```
# Install from this PR branch.
pip install git+https://github.com/danielballan/bluesky-widgets@adjust-qt-figure-size
```

<!--
## Screenshots (if appropriate):
-->
