### PR TITLE
Avoid using pyplot

### DIFF
--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -20,20 +20,20 @@ def _initialize_mpl():
 
 
 class JupyterAxes(_MatplotilbAxes):
-    # We need to turn `draw_idle` into "draw now" because they way
+    # We need to turn `draw_idle` into "draw now" because the way
     # that `draw_idle` is implemented requires a round-trip
     # communication with the js front end (from the Python side we say
-    # "dear JS, when you want ask us for an update".  The JS then
+    # "dear JS, when you want you to ask us for an update".  The JS then
     # sends back a message asking for the the figure to be rendered.
-    # This means we will not over-load the frontend with more updates
-    # than it want.
+    # This means we will not overload the frontend with more updates
+    # than it wants.
     #
-    # However, when a notebook cell is executing, the zmq loop than
+    # However, when a notebook cell is executing, the zmq loop that
     # processes messages from the front end is blocked so we never see
-    # the request for a re-draw so it looks "dead".
+    # the request for a re-draw. The figure looks "dead".
     #
-    # We do not see this problem with Qt because the default during
-    # task of the RE spins the Qt event loop while we wait on the
+    # We do not see this problem with Qt because the default "during
+    # task" of the RunEngine spins the Qt event loop while we wait on the
     # `_run` task in a background thread so the `draw_idle`
     # implementation throws a signal on the Qt event loop which gets
     # promptly serviced.  In contrast, the default during task when
@@ -141,7 +141,7 @@ class JupyterFigure(widgets.HBox):
         # This updates the Figure's internal state, setting its canvas.
         canvas = ipympl.backend_nbagg.Canvas(self.figure)
         label = "Figure"
-        # this will stash its self on the canvas
+        # this will stash itself on the canvas
         ipympl.backend_nbagg.FigureManager(canvas, 0)
         self.figure.set_label(label)
         self.children = (self.figure.canvas,)

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -1,5 +1,3 @@
-import collections.abc
-
 from ipywidgets import widgets
 import ipympl.backend_nbagg
 import matplotlib.figure

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -143,8 +143,9 @@ class JupyterFigure(widgets.HBox):
         # This updates the Figure's internal state, setting its canvas.
         canvas = ipympl.backend_nbagg.Canvas(self.figure)
         label = "Figure"
-        manager = ipympl.backend_nbagg.FigureManager(canvas, 0)
-        manager.set_window_title(label)
+        # this will stash its self on the canvas
+        ipympl.backend_nbagg.FigureManager(canvas, 0)
+        self.figure.set_label(label)
         self.children = (self.figure.canvas,)
 
         model.events.title.connect(self._on_title_changed)

--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -109,12 +109,9 @@ class JupyterFigure(widgets.HBox):
         # TODO Let Figure give different options to subplots here,
         # but verify that number of axes created matches the number of axes
         # specified.
-        raw_axes = self.figure.subplots(len(model.axes))
-        # Handle return type instability in mpl_Figure.subplots.
-        if not isinstance(raw_axes, collections.abc.Iterable):
-            self.axes_list = [raw_axes]
-        else:
-            self.axes_list = raw_axes
+        self.axes_list = list(
+            self.figure.subplots(len(model.axes), squeeze=False).ravel()
+        )
         self.figure.suptitle(model.title)
         self._axes = {}
         for axes_spec, axes in zip(model.axes, self.axes_list):

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -1,4 +1,3 @@
-import collections.abc
 import gc
 
 from qtpy.QtWidgets import (

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -162,12 +162,10 @@ class QtFigure(QWidget):
         # TODO Let Figure give different options to subplots here,
         # but verify that number of axes created matches the number of axes
         # specified.
-        raw_axes = self.figure.subplots(len(model.axes))
-        # Handle return type instability in mpl_Figure.subplots.
-        if not isinstance(raw_axes, collections.abc.Iterable):
-            self.axes_list = [raw_axes]
-        else:
-            self.axes_list = raw_axes
+        self.axes_list = list(
+            self.figure.subplots(len(model.axes), squeeze=False).ravel()
+        )
+
         self.figure.suptitle(model.title)
         self._axes = {}
         for axes_spec, axes in zip(model.axes, self.axes_list):


### PR DESCRIPTION
We currently abuse pyplot a little. This PR avoids using pyplot, but it also breaks interactive plotting in Jupyter. Until that is addressed, it shouldn't be merged.

A better solution might just be to avoid using matplotlib in Juptyer altogether.