### PR TITLE
WIP: Add option for displaying figures below cells that create them.

### DIFF
--- a/bluesky_widgets/jupyter/figures.py
+++ b/bluesky_widgets/jupyter/figures.py
@@ -1,4 +1,5 @@
 from ipywidgets import widgets
+from IPython.display import display
 import ipympl.backend_nbagg
 import matplotlib.figure
 
@@ -48,9 +49,10 @@ class JupyterFigures(widgets.Tab):
     A Jupyter (ipywidgets) view for a FigureList model.
     """
 
-    def __init__(self, model: FigureList, *args, **kwargs):
+    def __init__(self, model: FigureList, *args, display_in_current_output=False, **kwargs):
         _initialize_mpl()
         super().__init__(*args, **kwargs)
+        self.display_in_current_output = display_in_current_output
         self.model = model
         # Map Figure UUID to widget with JupyterFigureTab
         self._figures = {}
@@ -73,6 +75,8 @@ class JupyterFigures(widgets.Tab):
         "Add a new tab with a matplotlib Figure."
         tab = _JupyterFigureTab(figure_spec, parent=self)
         self._figures[figure_spec.uuid] = tab
+        if self.display_in_current_output:
+            display(tab.figure.canvas)
         self.children = (*self.children, tab)
         index = len(self.children) - 1
         self.set_title(index, figure_spec.title)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It is often useful to place the figure(s) in a tabbed viewer in one cell, rather than "plopping" them into the output area below the currently-running cell. However, there is still a use case for this mode of placing figure "in line" with the work. (Not to be confused with `%matplotlib inline` which kills interactive pan and zoom.) See #95.

See screenshot below.

TO DO

- [x] Add option for placing figures below running cell.
- [ ] Embed figures so that they can be viewed if the notebook is opened later. The action item here is probably just to wait for ipympl. They are [working on this](https://github.com/matplotlib/ipympl/pull/294). Perhaps, while we wait, we could implement `%matplotlib inline`-like behavior as a stop-gap. That is, when cell execution completes, close the figure and replace it with an embedded PNG.
- [ ] Tests

## Motivation and Context

Closes #95. See that issue for motivation and context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Needs tests

## Screenshots (if appropriate):


