### PR TITLE
Expose which figure is active

### DIFF
--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -544,7 +544,7 @@ class Image(ArtistSpec):
 
 
 class FigureList(EventedList):
-    __slots__ = ("_active_index")
+    __slots__ = ("_active_index",)
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._active_index = None

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -45,7 +45,7 @@ class Figure(BaseSpec):
         should fall back on ``title`` if this is None.
     """
 
-    __slots__ = ("_axes", "_title", "_short_title", "_active")
+    __slots__ = ("_axes", "_title", "_short_title")
 
     def __init__(self, axes, *, title, uuid=None, short_title=None):
         for ax in axes:
@@ -53,9 +53,7 @@ class Figure(BaseSpec):
         self._axes = tuple(axes)
         self._title = title
         self._short_title = short_title
-        self._active = None
-        self.events = EmitterGroup(source=self, title=Event, short_title=Event,
-                                   active=Event)
+        self.events = EmitterGroup(source=self, title=Event, short_title=Event)
         super().__init__(uuid)
 
     @property
@@ -89,15 +87,6 @@ class Figure(BaseSpec):
     def short_title(self, value):
         self._short_title = value
         self.events.short_title(value=value, figure_spec=self)
-
-    @property
-    def active(self):
-        return self._active
-
-    @active.setter
-    def active(self, value):
-        self._active = value
-        self.events.active(value=value)
 
     def __repr__(self):
         return (
@@ -558,19 +547,18 @@ class FigureList(EventedList):
     __slots__ = ("_active_index")
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO: maybe this should be active_uuid?
         self._active_index = None
+        self.events.add(active_index=Event)
 
     @property
     def active_index(self):
         "Return the index of the active figure."
-        for i, figure in enumerate(self):
-            if figure.active:
-                return i
+        return self._active_index
 
     @active_index.setter
     def active_index(self, value):
         self._active_index = value
+        self.events.active_index(value=value)
 
 
 class AxesList(EventedList):

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -545,6 +545,7 @@ class Image(ArtistSpec):
 
 class FigureList(EventedList):
     __slots__ = ("_active_index",)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._active_index = None

--- a/bluesky_widgets/models/plot_specs.py
+++ b/bluesky_widgets/models/plot_specs.py
@@ -45,7 +45,7 @@ class Figure(BaseSpec):
         should fall back on ``title`` if this is None.
     """
 
-    __slots__ = ("_axes", "_title", "_short_title")
+    __slots__ = ("_axes", "_title", "_short_title", "_active")
 
     def __init__(self, axes, *, title, uuid=None, short_title=None):
         for ax in axes:
@@ -53,7 +53,9 @@ class Figure(BaseSpec):
         self._axes = tuple(axes)
         self._title = title
         self._short_title = short_title
-        self.events = EmitterGroup(source=self, title=Event, short_title=Event)
+        self._active = None
+        self.events = EmitterGroup(source=self, title=Event, short_title=Event,
+                                   active=Event)
         super().__init__(uuid)
 
     @property
@@ -87,6 +89,15 @@ class Figure(BaseSpec):
     def short_title(self, value):
         self._short_title = value
         self.events.short_title(value=value, figure_spec=self)
+
+    @property
+    def active(self):
+        return self._active
+
+    @active.setter
+    def active(self, value):
+        self._active = value
+        self.events.active(value=value)
 
     def __repr__(self):
         return (
@@ -544,7 +555,22 @@ class Image(ArtistSpec):
 
 
 class FigureList(EventedList):
-    __slots__ = ()
+    __slots__ = ("_active_index")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # TODO: maybe this should be active_uuid?
+        self._active_index = None
+
+    @property
+    def active_index(self):
+        "Return the index of the active figure."
+        for i, figure in enumerate(self):
+            if figure.active:
+                return i
+
+    @active_index.setter
+    def active_index(self, value):
+        self._active_index = value
 
 
 class AxesList(EventedList):

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -158,11 +158,8 @@ class QtFigures(QTabWidget):
             self.setTabText(index, event.value)
 
     def _on_tab_changed(self, event):
-        for i, figure in enumerate(self.model):
-            if i == event:
-                figure.active = True
-            else:
-                figure.active = False
+        "Update the active_index in the FigureList."
+        self.model.active_index = event
 
 
 class QtFigure(QWidget):

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -157,9 +157,9 @@ class QtFigures(QTabWidget):
             index = self.indexOf(widget)
             self.setTabText(index, event.value)
 
-    def _on_tab_changed(self, event):
+    def _on_tab_changed(self, index):
         "Update the active_index in the FigureList."
-        self.model.active_index = event
+        self.model.active_index = index
 
 
 class QtFigure(QWidget):

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -78,6 +78,8 @@ class QtFigures(QTabWidget):
 
         self.__callback_event.connect(handle_callback)
 
+        self.currentChanged.connect(self._on_tab_changed)
+
     def sizeHint(self):
         size_hint = super().sizeHint()
         size_hint.setWidth(700)
@@ -154,6 +156,13 @@ class QtFigures(QTabWidget):
             widget = self._figures[figure_spec.uuid]
             index = self.indexOf(widget)
             self.setTabText(index, event.value)
+
+    def _on_tab_changed(self, event):
+        for i, figure in enumerate(self.model):
+            if i == event:
+                figure.active = True
+            else:
+                figure.active = False
 
 
 class QtFigure(QWidget):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new `active` property to `Figure` and a new `active_index` property to `FigureList`. `QtFigures` also updates the active figure when swapping between tabs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to be able to access the current figure in order to add plot builders to the correct plot.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested interactively with the `bluesky-widgets-demo`. 

<!--
## Screenshots (if appropriate):
-->
