### PR TITLE
'Plan Editor' widget

### DIFF
--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -1,5 +1,8 @@
+import ast
+import inspect
 import time
 import pprint
+import copy
 
 from qtpy.QtWidgets import (
     QWidget,
@@ -14,11 +17,19 @@ from qtpy.QtWidgets import (
     QHeaderView,
     QAbstractItemView,
     QTextEdit,
+    QTabWidget,
+    QRadioButton,
+    QButtonGroup,
+    QComboBox,
+    QSizePolicy,
+    QLineEdit,
+    QCheckBox,
 )
 from qtpy.QtCore import Qt, Signal, Slot, QTimer
-from qtpy.QtGui import QFontMetrics, QPalette
+from qtpy.QtGui import QFontMetrics, QPalette, QBrush, QColor
 
 from bluesky_widgets.qt.threading import FunctionWorker
+from bluesky_queueserver.manager.profile_ops import _construct_parameters
 
 
 class QtReManagerConnection(QWidget):
@@ -1260,3 +1271,1007 @@ class QtReRunningPlan(QWidget):
             self.model.running_item_add_to_queue()
         except Exception as ex:
             print(f"Exception: {ex}")
+
+
+# class FittedTextEdit(QTextEdit):
+#     def __init__(self):
+#         super().__init__()
+#         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
+#         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+#         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+#
+#     def sizeHint(self):
+#       s = self.document().size().toSize()
+#       print(f"width={s.width()} height={s.height()}")
+#       return s
+#
+#     def resizeEvent(self, event):
+#       self.updateGeometry()
+#       super().resizeEvent(event)
+
+
+class LineEditResized(QLineEdit):
+    def __init__(self):
+        super().__init__()
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self._hint_w = None
+
+        p = self.palette()
+        self._color_normal = p.color(QPalette.Normal, QPalette.Base)
+        self._color_disabled = p.color(QPalette.Disabled, QPalette.Base)
+
+    def setReadOnly(self, read_only):
+        super().setReadOnly(read_only)
+        p = self.palette()
+        if read_only:
+            p.setColor(QPalette.Base, self._color_disabled)
+        else:
+            p.setColor(QPalette.Base, self._color_normal)
+        self.setPalette(p)
+
+    def setTextAndResize(self, text, *, w_min=10, w_max=200, w_space=20):
+        self.setText(text)
+
+        fm = self.fontMetrics()
+        width = fm.boundingRect(text).width() + w_space
+        if w_max and (width > w_max):
+            width = w_max
+        if w_max < w_min:
+            width = w_min
+        self._hint_w = width
+
+    def sizeHint(self):
+        hint = super().sizeHint()
+        if self._hint_w is not None:
+            hint.setWidth(self._hint_w)
+        return hint
+
+
+class _QtRePlanEditorTable(QTableWidget):
+
+    signal_parameters_valid = Signal(bool)
+    signal_item_description_changed = Signal(str)
+
+    def __init__(self, model, parent=None, *, editable=False, detailed=True):
+        super().__init__(parent)
+        self.model = model
+
+        # Colors to display valid and invalid (based on validation) text entries in the table
+        self._text_color_valid = QTableWidgetItem().foreground()
+        self._text_color_invalid = QBrush(QColor(255, 0, 0))
+
+        self._validation_disabled = False
+
+        self._queue_item = None  # Copy of the displayed queue item
+        self._params = []
+        self._params_indices = []
+        self._params_descriptions = {}
+
+        self._item_meta = []
+        self._item_result = []
+
+        self._table_column_labels = ("Parameter", "", "Value")
+        self.setColumnCount(len(self._table_column_labels))
+        self.verticalHeader().hide()
+
+        self.setHorizontalHeaderLabels(self._table_column_labels)
+
+        self.setVerticalScrollMode(QAbstractItemView.ScrollPerItem)
+
+        self.setSelectionBehavior(QTableView.SelectRows)
+        self.setSelectionMode(QAbstractItemView.NoSelection)
+        self.setShowGrid(True)
+
+        self.setAlternatingRowColors(True)
+
+        self.horizontalHeader().setDefaultAlignment(Qt.AlignLeft)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setMinimumSectionSize(5)
+
+        self.itemChanged.connect(self.table_item_changed)
+
+        self._editable = editable  # Table is editable
+        self._detailed = (
+            detailed  # Detailed view of parameters (show all plan parameters)
+        )
+        self.show_item(item=None)
+
+    @property
+    def editable(self):
+        return self._editable
+
+    @editable.setter
+    def editable(self, is_editable):
+        if self._editable != is_editable:
+            self._editable = bool(is_editable)
+            self._fill_table()
+
+    @property
+    def detailed(self):
+        return self._detailed
+
+    @detailed.setter
+    def detailed(self, is_detailed):
+        if self._detailed != is_detailed:
+            self._detailed = bool(is_detailed)
+            self._fill_table()
+
+    @property
+    def queue_item(self):
+        """
+        Returns original queue item.
+        """
+        return self._queue_item
+
+    def get_modified_item(self):
+        """
+        Returns queue item that was modified during editing.
+        """
+        return self._params_to_item(self._params, self._queue_item)
+
+    def _clear_table(self):
+        self._params = []
+        self._params_indices = []
+        self.clearContents()
+        self.setRowCount(0)
+
+    def _item_to_params(self, item):
+
+        if item is None:
+            return [], {}, [], []
+
+        # Get plan parameters (probably should be a function call)
+        item_name = item.get("name", None)
+        item_type = item.get("item_type", None)
+        if item_type in ("plan", "instruction"):
+            if item_type == "plan":
+                item_params = self.model.get_allowed_plan_parameters(name=item_name)
+            else:
+                item_params = self.model.get_allowed_instruction_parameters(
+                    name=item_name
+                )
+            item_editable = (item_name is not None) and (item_params is not None)
+            params_descriptions = self.model.extract_descriptions_from_item_parameters(
+                item_parameters=item_params
+            )
+            params_descriptions = self.model.format_item_parameter_descriptions(
+                item_descriptions=params_descriptions
+            )
+        else:
+            raise RuntimeError(f"Unknown item type '{item_type}'")
+
+        item_args, item_kwargs = self.model.get_bound_item_arguments(item)
+        if item_args:
+            # Failed to bound the arguments. It is likely that the plan can not be submitted
+            #   so consider it not editable. Display 'args' as a separate parameter named 'ARGS'.
+            item_editable = False
+            item_kwargs = dict(**{"ARGS": item_args}, **item_kwargs)
+
+        # print(f"plan_params={pprint.pformat(plan_params)}")
+        if item_editable:
+            # Construct parameters (list of inspect.Parameter objects)
+            parameters, created_type_list = _construct_parameters(
+                item_params.get("parameters", {})
+            )
+            # print(f"parameters = {parameters}")
+            # print(f"default = {[_.default for _ in parameters]}")
+        else:
+            parameters = []
+            for key, val in item_kwargs.items():
+                p = inspect.Parameter(
+                    key,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=inspect.Parameter.empty,
+                    annotation=inspect.Parameter.empty,
+                )
+                parameters.append(p)
+
+        params = []
+        for p in parameters:
+            param_value = (
+                item_kwargs[p.name]
+                if (p.name in item_kwargs)
+                else inspect.Parameter.empty
+            )
+            is_value_set = (param_value != inspect.Parameter.empty) or (
+                p.default == inspect.Parameter.empty
+                and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+            )
+
+            # description = item_descriptions.get("parameters", {}).get(p.name, None)
+            # if not description:
+            #     description = f"Description for parameter {p.name} was not found ..."
+            params.append(
+                {
+                    "name": p.name,
+                    "value": param_value,
+                    "is_value_set": is_value_set,
+                    "parameters": p,
+                }
+            )
+
+        # If metadata exists, it will be displayed after the plan parameters
+        meta, item_meta = item.get("meta", {}), []
+        if meta:
+            if isinstance(meta, list):
+                for n, key in enumerate(meta):
+                    item_meta.append((f"METADATA {n}", ""))
+                    for k, v in key.items():
+                        item_meta.append((k, str(v)))
+            else:
+                item_meta.append(("METADATA", ""))
+                for k, v in meta.items():
+                    item_meta.append((f"- {k}", str(v)))
+
+        # If results of plan execution exist, they will be displayed after the plan parameters
+        result, item_result = item.get("result", {}), []
+        if result:
+            item_result.append(("RESULT", ""))
+            for k, v in result.items():
+                item_result.append((f"- {k}", str(v)))
+
+        return params, params_descriptions, item_meta, item_result
+
+    def _params_to_item(self, params, item):
+        item = copy.deepcopy(item)
+
+        # Find if there are VAR_POSITIONAL or VAR_KEYWORD arguments with set values
+        n_var_pos, n_var_kwd = -1, -1
+        for n, p in enumerate(params):
+            if p["is_value_set"] and (p["value"] != inspect.Parameter.empty):
+                if p["parameters"].kind == inspect.Parameter.VAR_POSITIONAL:
+                    n_var_pos = n
+                elif p["parameters"].kind == inspect.Parameter.VAR_KEYWORD:
+                    n_var_kwd = n
+
+        # Collect 'args'
+        args = []
+        if n_var_pos > 0:
+            if not isinstance(params[n_var_pos]["value"], (list, tuple)):
+                raise ValueError(
+                    f"Invalid type of VAR_POSITIONAL argument: {params[n_var_pos]['value']}"
+                )
+            for n in range(n_var_pos):
+                if params[n]["is_value_set"] and (
+                    params[n]["value"] != inspect.Parameter.empty
+                ):
+                    args.append(params[n]["value"])
+            args.extend(params[n_var_pos]["value"])
+
+        # Collect 'kwargs'
+        n_start = 0 if n_var_pos < 0 else n_var_pos + 1
+        n_stop = len(params) if n_var_kwd < 0 else n_var_kwd
+
+        kwargs = {}
+        for n in range(n_start, n_stop):
+            if params[n]["is_value_set"] and (
+                params[n]["value"] != inspect.Parameter.empty
+            ):
+                kwargs[params[n]["parameters"].name] = params[n]["value"]
+
+        if n_var_kwd > 0:
+            if not isinstance(params[n_var_kwd]["value"], dict):
+                raise ValueError(
+                    f"Invalid type of VAR_KEYWORD argument: {params[n_var_kwd]['value']}"
+                )
+            kwargs.update(params[n_var_kwd]["value"])
+
+        item["args"] = args
+        item["kwargs"] = kwargs
+
+        return item
+
+    def _show_row_value(self, *, row):
+        def print_value(v):
+            if isinstance(v, str):
+                return f"'{v}'"
+            else:
+                return str(v)
+
+        p = self._params[row]
+        p_name = p["name"]
+        value = p["value"]
+        default_value = p["parameters"].default
+        is_var_positional = p["parameters"].kind == inspect.Parameter.VAR_POSITIONAL
+        is_var_keyword = p["parameters"].kind == inspect.Parameter.VAR_KEYWORD
+        is_value_set = p["is_value_set"]
+        is_optional = (
+            (default_value != inspect.Parameter.empty)
+            or is_var_positional
+            or is_var_keyword
+        )
+        is_editable = self._editable and (is_value_set or not is_optional)
+
+        description = self._params_descriptions.get("parameters", {}).get(p_name, None)
+        if not description:
+            description = f"Description for parameter '{p_name}' was not found ..."
+
+        v = value if is_value_set else default_value
+        s_value = "" if v == inspect.Parameter.empty else print_value(v)
+        if not is_value_set and s_value:
+            s_value += " (default)"
+
+        # Set checkable item in column 1
+        check_item = QTableWidgetItem()
+        check_item.setFlags(check_item.flags() | Qt.ItemIsUserCheckable)
+        if not is_optional:
+            # Checked and disabled
+            check_item.setFlags(check_item.flags() & ~Qt.ItemIsEnabled)
+            check_item.setCheckState(Qt.Checked)
+        else:
+            if self._editable:
+                check_item.setFlags(check_item.flags() | Qt.ItemIsEnabled)
+            else:
+                check_item.setFlags(check_item.flags() & ~Qt.ItemIsEnabled)
+
+            if is_value_set:
+                check_item.setCheckState(Qt.Checked)
+            else:
+                check_item.setCheckState(Qt.Unchecked)
+
+        self.setItem(row, 1, check_item)
+
+        # Set value in column 2
+        value_item = QTableWidgetItem(s_value)
+
+        if is_editable:
+            value_item.setFlags(value_item.flags() | Qt.ItemIsEditable)
+        else:
+            value_item.setFlags(value_item.flags() & ~Qt.ItemIsEditable)
+
+        if is_value_set:
+            value_item.setFlags(value_item.flags() | Qt.ItemIsEnabled)
+        else:
+            value_item.setFlags(value_item.flags() & ~Qt.ItemIsEnabled)
+
+        value_item.setToolTip(description)
+
+        self.setItem(row, 2, value_item)
+
+    def _fill_table(self):
+        def print_value(v):
+            if isinstance(v, str):
+                return f"'{v}'"
+            else:
+                return str(v)
+
+        self._validation_disabled = True
+        self.clearContents()
+
+        params = self._params
+        params_descriptions = self._params_descriptions
+        item_meta = self._item_meta
+        item_result = self._item_result
+
+        # By default select all indexes of 'params'
+        self._params_indices = list(range(len(params)))
+        params_indices = self._params_indices
+
+        # Remove parameters with default values (only when editing is disabled)
+        if (not self._editable) and (not self._detailed):
+            params_indices.clear()
+            for n, p in enumerate(params):
+                if p["value"] != inspect.Parameter.empty:
+                    params_indices.append(n)
+
+        self.setRowCount(len(params_indices) + len(item_meta) + len(item_result))
+
+        for n, p_index in enumerate(params_indices):
+            p = params[p_index]
+
+            is_var_positional = p["parameters"].kind == inspect.Parameter.VAR_POSITIONAL
+            is_var_keyword = p["parameters"].kind == inspect.Parameter.VAR_KEYWORD
+
+            key = p["parameters"].name
+            value = p["value"]
+            default_value = p["parameters"].default
+
+            description = params_descriptions.get("parameters", {}).get(key, None)
+            if not description:
+                description = (
+                    f"Description for parameter '{self._queue_item.get('name', '-')}' "
+                    f"was not found ..."
+                )
+
+            is_value_set = p["is_value_set"]
+
+            v = value if is_value_set else default_value
+            s_value = "" if v == inspect.Parameter.empty else print_value(v)
+            if not is_value_set:
+                s_value += " (default)"
+
+            key_name = str(key)
+            if is_var_positional:
+                key_name = f"*{key_name}"
+            elif is_var_keyword:
+                key_name = f"**{key_name}"
+            key_item = QTableWidgetItem(key_name)
+            key_item.setToolTip(description)
+            key_item.setFlags(key_item.flags() & ~Qt.ItemIsEditable)
+            self.setItem(n, 0, key_item)
+
+            self._show_row_value(row=n)
+
+        # Display metadata (if exists)
+        n_row = len(params_indices)  # Number of table row
+        for k, v in item_meta:
+            key_item = QTableWidgetItem(str(k))
+            key_item.setFlags(key_item.flags() & ~Qt.ItemIsEditable)
+            self.setItem(n_row, 0, key_item)
+            value_item = QTableWidgetItem(str(v))
+            value_item.setFlags(key_item.flags() & ~Qt.ItemIsEditable)
+            self.setItem(n_row, 2, value_item)
+            n_row += 1
+
+        # Display results (if exist)
+        for k, v in item_result:
+            key_item = QTableWidgetItem(str(k))
+            key_item.setFlags(key_item.flags() & ~Qt.ItemIsEditable)
+            self.setItem(n_row, 0, key_item)
+            value_item = QTableWidgetItem(str(v))
+            value_item.setFlags(key_item.flags() & ~Qt.ItemIsEditable)
+            self.setItem(n_row, 2, value_item)
+            n_row += 1
+
+        self._validation_disabled = False
+        self._validate_cell_values()
+
+    def show_item(self, *, item, editable=None):
+        if editable is not None:
+            self._editable = bool(editable)
+
+        # Keep the copy of the queue item
+        self._queue_item = copy.deepcopy(item)
+        self.reset_item()
+
+    def reset_item(self):
+        # Generate parameters
+        (
+            self._params,
+            self._params_descriptions,
+            self._item_meta,
+            self._item_result,
+        ) = self._item_to_params(self._queue_item)
+        if not self._queue_item:
+            self._clear_table()
+            description = ""
+        else:
+            self._fill_table()
+
+            description = self._params_descriptions.get("description", "")
+            if not description:
+                name = self._queue_item.get("name", "-")
+                description = f"Description for the item '{name}' was not found ..."
+
+        # Send the signal that updates item description somewhere else in the code
+        self.signal_item_description_changed.emit(description)
+
+    def _validate_cell_values(self):
+        """
+        Validates each cell in the table that is expected to have manually entered parameters.
+        Skips the cells that display the default parameters.
+
+        The function also saves successfully evaluated values to the parameter list.
+
+        Signal is emitted to report results of parameter validation (may be used to
+        enable/disable buttons in other widges, e.g. 'Ok' button).
+        """
+        # Validation may be disabled while the table is being filled.
+        if self._validation_disabled:
+            return
+
+        data_valid = True
+        for n, p_index in enumerate(self._params_indices):
+            p = self._params[p_index]
+            if p["is_value_set"]:
+                table_item = self.item(n, 2)
+
+                if table_item:
+                    cell_valid = True
+                    cell_text = table_item.text()
+                    try:
+                        # Currently the simples verification is performed:
+                        #   - The cell is evaluated.
+                        #   - If the evaluation is successful, then the value is saved.
+                        # TODO: verify type of the loaded value whenever possible
+                        p["value"] = ast.literal_eval(cell_text)
+                    except Exception:
+                        cell_valid = False
+                        data_valid = False
+
+                    table_item.setForeground(
+                        self._text_color_valid
+                        if cell_valid
+                        else self._text_color_invalid
+                    )
+
+        self.signal_parameters_valid.emit(data_valid)
+
+    def table_item_changed(self, table_item):
+        try:
+            row = self.row(table_item)
+            column = self.column(table_item)
+            if column == 1:
+                is_checked = table_item.checkState() == Qt.Checked
+                if self._params[row]["is_value_set"] != is_checked:
+
+                    if (
+                        is_checked
+                        and self._params[row]["value"] == inspect.Parameter.empty
+                    ):
+                        self._params[row]["value"] = self._params[row][
+                            "parameters"
+                        ].default
+
+                    self._params[row]["is_value_set"] = is_checked
+                    self._show_row_value(row=row)
+
+            elif column == 2:
+                self._validate_cell_values()
+        except ValueError:
+            pass
+
+
+class _QtReViewer(QWidget):
+
+    signal_update_widgets = Signal()
+    signal_update_selection = Signal(int)
+    signal_edit_queue_item = Signal(object)
+
+    def __init__(self, model, parent=None):
+        super().__init__(parent)
+        self.model = model
+
+        self._queue_item_name = ""
+        self._queue_item_type = None
+
+        self._lb_item_type = QLabel("Plan:")
+        self._lb_item_name_default = "-"
+        self._lb_item_name = QLabel(self._lb_item_name_default)
+        self._cb_show_optional = QCheckBox("All Parameters")
+        self._lb_item_source = QLabel("QUEUE ITEM")
+
+        self._pb_copy_to_queue = QPushButton("Copy to Queue")
+        self._pb_edit = QPushButton("Edit")
+
+        # Start with 'detailed' view (show optional parameters)
+        self._wd_editor = _QtRePlanEditorTable(
+            self.model, editable=False, detailed=True
+        )
+        self._cb_show_optional.setChecked(
+            Qt.Checked if self._wd_editor.detailed else Qt.Unchecked
+        )
+
+        vbox = QVBoxLayout()
+        hbox = QHBoxLayout()
+        hbox.addWidget(self._lb_item_type)
+        hbox.addWidget(self._lb_item_name)
+        hbox.addStretch(5)
+        hbox.addWidget(self._cb_show_optional)
+        hbox.addStretch(1)
+        hbox.addWidget(self._lb_item_source)
+        vbox.addLayout(hbox)
+
+        vbox.addWidget(self._wd_editor)
+
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(self._pb_copy_to_queue)
+        hbox.addWidget(self._pb_edit)
+        vbox.addLayout(hbox)
+
+        self.setLayout(vbox)
+
+        self._cb_show_optional.stateChanged.connect(
+            self._cb_show_optional_state_changed
+        )
+        self._pb_copy_to_queue.clicked.connect(self._pb_copy_to_queue_clicked)
+        self._pb_edit.clicked.connect(self._pb_edit_clicked)
+
+        self.model.events.queue_item_selection_changed.connect(
+            self.on_queue_item_selection_changed
+        )
+        self.signal_update_selection.connect(self.slot_change_selection)
+
+        self.model.events.status_changed.connect(self.on_update_widgets)
+        self.signal_update_widgets.connect(self.slot_update_widgets)
+
+        self._wd_editor.signal_item_description_changed.connect(
+            self.slot_item_description_changed
+        )
+
+    def on_queue_item_selection_changed(self, event):
+        sel_item_uid = event.selected_item_uid
+        sel_item_pos = self.model.queue_item_uid_to_pos(sel_item_uid)
+        self.signal_update_selection.emit(sel_item_pos)
+
+    def on_update_widgets(self, event):
+        self.signal_update_widgets.emit()
+
+    @Slot()
+    def slot_update_widgets(self):
+        self._update_widget_state()
+
+    def _update_widget_state(self):
+        item_name = self._queue_item_name
+        item_type = self._queue_item_type
+
+        if item_type == "plan":
+            is_item_allowed = (
+                self.model.get_allowed_plan_parameters(name=item_name) is not None
+            )
+        elif item_type == "instruction":
+            is_item_allowed = (
+                self.model.get_allowed_instruction_parameters(name=item_name)
+                is not None
+            )
+        else:
+            is_item_allowed = False
+
+        is_connected = bool(self.model.re_manager_connected)
+
+        self._pb_copy_to_queue.setEnabled(is_item_allowed and is_connected)
+        self._pb_edit.setEnabled(is_item_allowed)
+
+    @Slot(str)
+    def slot_item_description_changed(self, item_description):
+        self._lb_item_name.setToolTip(item_description)
+
+    @Slot(int)
+    def slot_change_selection(self, sel_item_pos):
+        if sel_item_pos >= 0:
+            item = copy.deepcopy(self.model._plan_queue_items[sel_item_pos])
+        else:
+            item = None
+
+        default_name = self._lb_item_name_default
+        self._queue_item_name = item.get("name", default_name) if item else default_name
+        self._queue_item_type = item.get("item_type", None) if item else None
+
+        # Displayed item type is supposed to be 'Instruction:' if an instruction is selected,
+        #   otherwise it should be 'Plan:' (even if nothing is selected)
+        displayed_item_type = (
+            "Instruction:" if self._queue_item_type == "instruction" else "Plan:"
+        )
+        self._lb_item_type.setText(displayed_item_type)
+
+        self._lb_item_name.setText(self._queue_item_name)
+
+        self._update_widget_state()
+        self._wd_editor.show_item(item=item)
+
+    def _cb_show_optional_state_changed(self, state):
+        is_checked = state == Qt.Checked
+        self._wd_editor.detailed = is_checked
+
+    def _pb_copy_to_queue_clicked(self):
+        """
+        Copy currently selected item to queue.
+        """
+        try:
+            self.model.queue_item_copy_to_queue()
+        except Exception as ex:
+            print(f"Exception: {ex}")
+
+    def _pb_edit_clicked(self):
+        sel_item_uid = self.model.selected_queue_item_uid
+        sel_item = self.model.queue_item_by_uid(sel_item_uid)  # Returns deep copy
+        self.signal_edit_queue_item.emit(sel_item)
+
+
+class _QtReEditor(QWidget):
+
+    signal_update_widgets = Signal()
+    signal_switch_tab = Signal(str)
+    signal_allowed_plan_changed = Signal()
+
+    def __init__(self, model, parent=None):
+        super().__init__(parent)
+        self.model = model
+
+        self._queue_item_type = None  # ???
+        self._queue_item_name = None  # ???
+
+        self._current_item_type = "plan"
+        self._current_plan_name = ""
+        self._current_instruction_name = ""
+        self._current_item_source = ""  # Values: "", "NEW ITEM", "QUEUE ITEM"
+
+        self._queue_item_loaded = False
+        self._editor_state_valid = False
+
+        self._rb_item_plan = QRadioButton("Plan")
+        self._rb_item_plan.setChecked(True)
+        self._rb_item_instruction = QRadioButton("Instruction")
+        self._grp_item_type = QButtonGroup()
+        self._grp_item_type.addButton(self._rb_item_plan)
+        self._grp_item_type.addButton(self._rb_item_instruction)
+
+        self._combo_item_list = QComboBox()
+        self._combo_item_list.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        # self._combo_item_list.setSizePolicy(QComboBox.AdjustToContents)
+        self._combo_item_list.currentIndexChanged.connect(
+            self._combo_item_list_sel_changed
+        )
+
+        self._pb_new_item = QPushButton("New")
+        self._lb_item_source = QLabel(self._current_item_source)
+
+        # Start with 'detailed' view (show optional parameters)
+        self._wd_editor = _QtRePlanEditorTable(
+            self.model, editable=False, detailed=True
+        )
+        self._wd_editor.signal_parameters_valid.connect(self._slot_parameters_valid)
+        self._wd_editor.signal_item_description_changed.connect(
+            self._slot_item_description_changed
+        )
+
+        self._pb_add_to_queue = QPushButton("Add to Queue")
+        self._pb_save_item = QPushButton("Save")
+        self._pb_reset = QPushButton("Reset")
+        self._pb_cancel = QPushButton("Cancel")
+
+        self._pb_new_item.clicked.connect(self._pb_new_item_clicked)
+        self._pb_add_to_queue.clicked.connect(self._pb_add_to_queue_clicked)
+        self._pb_save_item.clicked.connect(self._pb_save_item_clicked)
+        self._pb_reset.clicked.connect(self._pb_reset_clicked)
+        self._pb_cancel.clicked.connect(self._pb_cancel_clicked)
+
+        self._grp_item_type.buttonToggled.connect(self._grp_item_type_button_toggled)
+
+        vbox = QVBoxLayout()
+        hbox = QHBoxLayout()
+        hbox.addWidget(self._rb_item_plan)
+        hbox.addWidget(self._rb_item_instruction)
+        hbox.addWidget(self._combo_item_list)
+        hbox.addStretch(1)
+        hbox.addWidget(self._pb_new_item)
+        hbox.addWidget(self._lb_item_source)
+        vbox.addLayout(hbox)
+
+        vbox.addWidget(self._wd_editor)
+
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(self._pb_add_to_queue)
+        hbox.addWidget(self._pb_save_item)
+        hbox.addWidget(self._pb_reset)
+        hbox.addWidget(self._pb_cancel)
+        vbox.addLayout(hbox)
+
+        self.setLayout(vbox)
+
+        self.model.events.allowed_plans_changed.connect(self._on_allowed_plans_changed)
+        self.signal_allowed_plan_changed.connect(self._slot_allowed_plans_changed)
+
+        self.model.events.status_changed.connect(self.on_update_widgets)
+        self.signal_update_widgets.connect(self.slot_update_widgets)
+
+        self._set_allowed_item_list()
+
+        self._update_widget_state()
+
+    def _set_allowed_item_list(self):
+        # self._queue_item_type must be "plan" or "instruction"
+        # self._current_plan_name and self._current_item_name should be properly set.
+        #   The first item in the list is selected if the value is set to "".
+        #   No element selected if the element with the given name is not in the list.
+
+        if self._current_item_type == "plan":
+            allowed_item_names = self.model.get_allowed_plan_names()
+            if (not self._current_plan_name) and (allowed_item_names):
+                self._current_plan_name = allowed_item_names[0]
+            item_name = self._current_plan_name
+
+        elif self._current_item_type == "instruction":
+            allowed_item_names = self.model.get_allowed_instruction_names()
+            if (not self._current_instruction_name) and (allowed_item_names):
+                self._current_instruction_name = allowed_item_names[0]
+            item_name = self._current_instruction_name
+
+        self._combo_item_list.clear()
+        self._combo_item_list.addItems(allowed_item_names)
+
+        try:
+            index = allowed_item_names.index(item_name)
+        except ValueError:
+            index = -1
+
+        self._combo_item_list.setCurrentIndex(index)
+
+    def _update_widget_state(self):
+
+        is_connected = bool(self.model.re_manager_connected)
+
+        self._rb_item_plan.setEnabled(not self._queue_item_loaded)
+        self._rb_item_instruction.setEnabled(not self._queue_item_loaded)
+        self._combo_item_list.setEnabled(not self._queue_item_loaded)
+        self._pb_new_item.setEnabled(not self._queue_item_loaded)
+        self._pb_new_item.setVisible(not self._queue_item_loaded)
+
+        self._pb_add_to_queue.setEnabled(self._editor_state_valid and is_connected)
+        self._pb_save_item.setEnabled(
+            self._editor_state_valid
+            and is_connected
+            and self._current_item_source == "QUEUE ITEM"
+        )
+        self._pb_reset.setEnabled(self._queue_item_loaded)
+        self._pb_cancel.setEnabled(self._queue_item_loaded)
+
+        self._lb_item_source.setText(self._current_item_source)
+
+    def edit_queue_item(self, queue_item):
+        self._current_item_source = "QUEUE ITEM"
+        self._edit_item(queue_item)
+
+    def _edit_item(self, queue_item):
+        self._queue_item_name = queue_item.get("name", None)
+        self._queue_item_type = queue_item.get("item_type", None)
+
+        if (
+            self._queue_item_name
+            and self._queue_item_type
+            and self._queue_item_type in ("plan", "instruction")
+        ):
+
+            if self._queue_item_type == "instruction":
+                self._current_instruction_name = self._queue_item_name
+                self._rb_item_instruction.setChecked(True)
+            else:
+                self._current_plan_name = self._queue_item_name
+                self._rb_item_plan.setChecked(True)
+
+            self._set_allowed_item_list()
+
+            self._wd_editor.show_item(item=queue_item, editable=True)
+
+            self._queue_item_loaded = True
+            self._update_widget_state()
+
+    def _show_item_preview(self):
+        """
+        Generate and display preview (not editable)
+        """
+        item_name = self._combo_item_list.currentText()
+        item_type = self._current_item_type
+        if item_name:
+            item = {"item_type": item_type, "name": item_name}
+            self._wd_editor.show_item(item=item, editable=False)
+
+    def _save_selected_item_name(self):
+        item_name = self._combo_item_list.currentText()
+        item_type = self._current_item_type
+        if item_name:
+            if item_type == "plan":
+                self._current_plan_name = item_name
+            elif item_type == "instruction":
+                self._current_instruction_name = item_name
+
+    def on_update_widgets(self, event):
+        self.signal_update_widgets.emit()
+
+    @Slot()
+    def slot_update_widgets(self):
+        self._update_widget_state()
+
+    @Slot(str)
+    def _slot_item_description_changed(self, item_description):
+        self._combo_item_list.setToolTip(item_description)
+
+    @Slot(bool)
+    def _slot_parameters_valid(self, is_valid):
+        self._editor_state_valid = is_valid
+        self._update_widget_state()
+
+    def _pb_new_item_clicked(self):
+        item_type = self._current_item_type
+        item_name = self._combo_item_list.currentText()
+        if item_name:
+            new_item = {"item_type": item_type, "name": item_name}
+            self._current_item_source = "NEW ITEM"
+            self._edit_item(new_item)
+
+    def _pb_add_to_queue_clicked(self):
+        """
+        Add item to queue
+        """
+        item = self._wd_editor.get_modified_item()
+        try:
+            self.model.queue_item_add(item=item)
+            self._wd_editor.show_item(item=None)
+            self.signal_switch_tab.emit("view")
+            self._queue_item_loaded = False
+            self._current_item_source = ""
+            self._update_widget_state()
+            self._show_item_preview()
+
+        except Exception as ex:
+            print(f"Exception: {ex}")
+
+    def _pb_save_item_clicked(self):
+        """
+        Save item to queue (update the edited item)
+        """
+        item = self._wd_editor.get_modified_item()
+        try:
+            self.model.queue_item_update(item=item)
+            self._wd_editor.show_item(item=None)
+            self.signal_switch_tab.emit("view")
+            self._queue_item_loaded = False
+            self._current_item_source = ""
+            self._update_widget_state()
+            self._show_item_preview()
+        except Exception as ex:
+            print(f"Exception: {ex}")
+
+    def _pb_reset_clicked(self):
+        """
+        Restore parameters to the original values
+        """
+        self._wd_editor.reset_item()
+
+    def _pb_cancel_clicked(self):
+        self._wd_editor.show_item(item=None)
+        self._queue_item_loaded = False
+        self._queue_item_type = ""
+        self._queue_item_name = ""
+        self._current_item_source = ""
+        self._update_widget_state()
+        self._show_item_preview()
+
+    def _grp_item_type_button_toggled(self, button, checked):
+        if checked:
+            if button == self._rb_item_plan:
+                self._current_item_type = "plan"
+                self._set_allowed_item_list()
+            elif button == self._rb_item_instruction:
+                self._current_item_type = "instruction"
+                self._set_allowed_item_list()
+
+    def _combo_item_list_sel_changed(self, index):
+        self._save_selected_item_name()
+        # We don't process the case when the list of allowed plans changes and the selected
+        #   item is not in the list. But this is not a practical case.
+        if not self._queue_item_loaded:
+            self._show_item_preview()
+
+    def _on_allowed_plans_changed(self, allowed_plans):
+        self.signal_allowed_plan_changed.emit()
+
+    @Slot()
+    def _slot_allowed_plans_changed(self):
+        self._set_allowed_item_list()
+
+
+class QtRePlanEditor(QWidget):
+    signal_update_widgets = Signal()
+    signal_running_item_changed = Signal(object, object)
+
+    def __init__(self, model, parent=None):
+        super().__init__(parent)
+        self.model = model
+
+        self._plan_viewer = _QtReViewer(model)
+        self._plan_editor = _QtReEditor(model)
+
+        self._tab_widget = QTabWidget()
+        self._tab_widget.addTab(self._plan_viewer, "Plan Viewer")
+        self._tab_widget.addTab(self._plan_editor, "Plan Editor")
+
+        vbox = QVBoxLayout()
+        vbox.addWidget(self._tab_widget)
+        self.setLayout(vbox)
+
+        self._plan_viewer.signal_edit_queue_item.connect(self._edit_queue_item)
+        self._plan_editor.signal_switch_tab.connect(self._switch_tab)
+
+    @Slot(str)
+    def _switch_tab(self, tab):
+        tabs = {"view": self._plan_viewer, "edit": self._plan_editor}
+        self._tab_widget.setCurrentWidget(tabs[tab])
+
+    @Slot(object)
+    def _edit_queue_item(self, queue_item):
+        self._switch_tab("edit")
+        self._plan_editor.edit_queue_item(queue_item)

--- a/bluesky_widgets/qt/run_tree.py
+++ b/bluesky_widgets/qt/run_tree.py
@@ -12,7 +12,7 @@ from databroker.core import BlueskyEventStream
 
 
 class RunTree:
-    """Lazily populate the tree as data is requested. """
+    """Lazily populate the tree as data is requested."""
 
     def __init__(self, bs_run):
         self.run = bs_run
@@ -170,7 +170,7 @@ class TreeViewModel(QAbstractItemModel):
         return QModelIndex()
 
     def parent(self, index):
-        """ Return the parent."""
+        """Return the parent."""
         if not index.isValid:
             return QModelIndex()
         item = index.internalPointer()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of 'Plan Editor' widget (`QtRePlanEditor`). The widget contains plan viewer and plan editor located in separate tabs. The viewer and the editor are independent: the editor displays the plan opened for editing and the viewer displays the parameters of the item selected in Queue Management widget. A plan can be opened for editing by pressing `Edit` button in the Plan Viewer tab. To create a new item, press `New` button in Plan Editor tab. When a plan is open for editing, the `New` button is invisible and item selection controls (radio buttons and combo box at the top) are disabled. Adding opened item to queue, saving it or closing it (`Cancel` button) enables the item selection controls.

If the plan is annotated, the plan and parameter descriptions are shown as tooltips for table items and the widget displaying the plan name (QLabel in viewer and QComboBox in editor). The simplest way to annotate a plan is to provide the docstring with the description of each parameter and specify types and default values in the plan header:

```
def plan1(param1: float, param2: int=10):
    """
    Description of the plan will be displayed.

    Parameters
    ---------------
    param1 : float
        The description of 'param1' will be displayed, but type specification will be ignored. 
        Type from the function signature will be displayed.
    param2 : int
        Type and default value from function signature will be displayed.
    """
    < plan body >
    ....
```
Alternative way to annotate function is to use https://github.com/bluesky/bluesky-queueserver/blob/a57ca238c0535a7c88bcc9a9b2c04bbf0d4a78fd/bluesky_queueserver/manager/annotation_decorator.py#L352 . All decorator parameters are optional and will override the respective entries in docstring and function header. The decorator will likely to be modified in the nearest future and is not recommended for deployment at this point.

It is not recommended to strongly rely on VAR_POSITIONAL and VAR_KEYWORD arguments, but use keyword arguments
with informative names. The following plan will never be nicely displayed in the Plan Viewer or will be easy to edit in the Plan Editor:

```
def plan2(*args, **kwargs):
    <plan body>
```

![image](https://user-images.githubusercontent.com/46980826/116283681-2a175700-a75a-11eb-9602-0ca32df8895c.png)
![image](https://user-images.githubusercontent.com/46980826/116283780-4e733380-a75a-11eb-94a5-d7cab1719aeb.png)

The code in this PR is developed for forthcoming demo presentation and will have to be refactored in the future.
