### PR TITLE
ENH: generate 'history_item_process' event

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -76,6 +76,7 @@ class RunEngineClient:
             allowed_plans_changed=Event,
             queue_item_selection_changed=Event,
             history_item_selection_changed=Event,
+            history_item_process=Event,
         )
 
     @property
@@ -821,6 +822,20 @@ class RunEngineClient:
         if selected_item_pos >= 0:
             history_item = self._plan_history_items[selected_item_pos]
             self.queue_item_add(item=history_item)
+
+    def history_item_send_to_processing(self):
+        """
+        Emits the event ``history_item_process`` sending the currently selected
+        item as a parameter. The function should be called in response to some user
+        action on the selected item (e.g. double clicking the item). The event
+        can may be received by a widget that performs some processing of the item,
+        e.g. loading from data broker and plotting the experimental data
+        """
+        selected_item_pos = self.selected_history_item_pos
+        if selected_item_pos >= 0:
+            # Copy data before sending it for processing by another model
+            history_item = copy.deepcopy(self._plan_history_items[selected_item_pos])
+            self.events.history_item_process(item=history_item)
 
     def history_clear(self):
         """

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -962,6 +962,7 @@ class QtRePlanHistory(QWidget):
         self._table.itemSelectionChanged.connect(self.on_item_selection_changed)
         self._table.verticalScrollBar().valueChanged.connect(self.on_vertical_scrollbar_value_changed)
         self._table.verticalScrollBar().rangeChanged.connect(self.on_vertical_scrollbar_range_changed)
+        self._table.cellDoubleClicked.connect(self._on_table_cell_double_clicked)
 
         self._update_button_states()
 
@@ -1060,6 +1061,12 @@ class QtRePlanHistory(QWidget):
         """
         row = event.selected_item_pos
         self.signal_update_selection.emit(row)
+
+    def _on_table_cell_double_clicked(self, n_row, n_col):
+        """
+        Double-clicking of an item of the table widget: send the item (plan) for processing.
+        """
+        self.model.history_item_send_to_processing()
 
     @Slot(int)
     def slot_change_selection(self, selected_item_pos):


### PR DESCRIPTION
Generate `history_item_process` event of the model `RunEngineClient` in response to double-clicking of an item in the history table. The event is delivering the dictionary of the selected history item parameters as a parameter `item`. The exit status of the plan may be found as `item["result"]["exit_status"]` and the list of run UIDS as `item["result"]["run_uids"]`.

It is recommended to verify that the keys "result", "exit_status" and "run_uids" are present in the dictionary to prevent crashes in case the history contains corrupted items.