### PR TITLE
Made plot_builders an EventedList

### DIFF
--- a/bluesky_widgets/models/auto_plot_builders/_base.py
+++ b/bluesky_widgets/models/auto_plot_builders/_base.py
@@ -2,6 +2,7 @@ import abc
 
 from ..plot_specs import FigureList
 from ..utils import run_is_live_and_not_completed
+from ...utils.list import EventedList
 
 
 class AutoPlotter(abc.ABC):
@@ -20,7 +21,7 @@ class AutoPlotter(abc.ABC):
     def __init__(self):
         self.figures = FigureList()
         self.figures.events.removed.connect(self._on_figure_removed)
-        self.plot_builders = []
+        self.plot_builders = EventedList()
 
     def add_run(self, run, **kwargs):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As stated in title.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to be able to track when `plot_builders` are removed in the `AutoPlotter` for the bluesky-widgets-demo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested interactively with the bluesky-widgets-demo for BMM. See [link](https://github.com/NSLS-II-BMM/ariadne/pull/5) for screenshots.
<!--
## Screenshots (if appropriate):
-->
