### PR TITLE
Fix key in AutoImages

### DIFF
--- a/bluesky_widgets/models/auto_plot_builders/_images.py
+++ b/bluesky_widgets/models/auto_plot_builders/_images.py
@@ -51,11 +51,12 @@ class AutoImages(AutoPlotter):
         ds = run[stream_name].to_dask()
         for field in ds:
             if 2 <= ds[field].ndim < 5:
+                key = (stream_name, field, run.metadata['start']['uid'])
                 try:
-                    images = self._field_to_builder[(stream_name, field)]
+                    images = self._field_to_builder[key]
                 except KeyError:
                     images = Images(field=field, needs_streams=(stream_name,))
-                    self._field_to_builder[(stream_name, field)] = images
+                    self._field_to_builder[key] = images
+                    self.plot_builders.append(images)
+                    self.figures.append(images.figure)
                 images.add_run(run)
-                self.plot_builders.append(images)
-                self.figures.append(images.figure)

--- a/bluesky_widgets/models/auto_plot_builders/_images.py
+++ b/bluesky_widgets/models/auto_plot_builders/_images.py
@@ -51,7 +51,7 @@ class AutoImages(AutoPlotter):
         ds = run[stream_name].to_dask()
         for field in ds:
             if 2 <= ds[field].ndim < 5:
-                key = (stream_name, field, run.metadata['start']['uid'])
+                key = (stream_name, field, run.metadata["start"]["uid"])
                 try:
                     images = self._field_to_builder[key]
                 except KeyError:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `run` `uid` to the `_field_to_builders` dictionary key in `AutoImages` `handle_new_stream` function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Figures were being overwritten when new runs were coming in. Previous keys weren't specific enough to differentiate between runs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested interactively with the bluesky-widgets-demo.

<!--
## Screenshots (if appropriate):
-->
