### PR TITLE
Plan Editor: Option to upload plans from a spreadsheet

### DIFF
--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -2430,7 +2430,7 @@ class DialogBatchUpload(QDialog):
         if file_path:
             self._file_path = file_path
             self._current_dir, _ = os.path.split(file_path)
-            self._le_file_name.setText(self._current_dir)
+            self._le_file_name.setText(file_path)
             self.pb_ok.setEnabled(True)
 
     def _pb_ok_clicked(self):


### PR DESCRIPTION
Extention of a Plan Editor Widget: implementation of an option that allows uploading plans from a spreadsheet. Plan Editor widget is now contains an additional button 'Batch Upload':
![image](https://user-images.githubusercontent.com/46980826/118586399-ab19ab00-b768-11eb-9005-0875ac247d5f.png)

Clicking on the `Batch Upload` button opens `Batch Upload` dialog box:
![image](https://user-images.githubusercontent.com/46980826/118586502-df8d6700-b768-11eb-9d77-83e9c65526b2.png)

The dialog box contains the button `..`, which opens standard dialog for selection of an existing file and optional combo box for selecting spreadsheet type. The list of spreadsheet types (strings) may be set during initialization of the model. If the list is not set, then the combo box is not displayed:
![image](https://user-images.githubusercontent.com/46980826/118587359-7870b200-b76a-11eb-9036-9c71af131c45.png)

Once the file is selected, the `Ok` button is enabled.
![image](https://user-images.githubusercontent.com/46980826/118587471-a9e97d80-b76a-11eb-98d8-05dbb86c20c7.png)

Pressing the `Ok` button adds the plans to the queue. The block of newly inserted items is automatically selected so that queue operations (copy/delete/move) could be applied to the block.
![image](https://user-images.githubusercontent.com/46980826/118587003-c507bd80-b769-11eb-9985-6e32318a61e5.png)

