### PR TITLE
Replace emulated batch operations by calling batch APIs for controlling the queue

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -898,7 +898,7 @@ class RunEngineClient:
         if not items:
             return
 
-        sel_item_uids = self._selected_queue_item_uids.copy()
+        sel_item_uids = self.selected_queue_item_uids.copy()
 
         if sel_item_uids:
             # Insert after the last item in the selected batch
@@ -937,7 +937,6 @@ class RunEngineClient:
                     f"{pprint.pformat(response)}. Can not update item selection in the queue table. "
                     f"Exception: {ex}"
                 )
-            print(f"sel_item_uids = {sel_item_uids}")  ##
             self.selected_queue_item_uids = sel_item_uids
 
     def queue_upload_spreadsheet(self, *, file_path, data_type=None):

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -725,7 +725,7 @@ class QtRePlanQueue(QWidget):
         self._n_table_items = 0  # The number of items in the table
         self._selected_items_pos = []  # Selected items (list of table rows)
 
-        self._pb_move_up = PushButtonMinimumWidth("Move Up")
+        self._pb_move_up = PushButtonMinimumWidth("Up")
         self._pb_move_down = PushButtonMinimumWidth("Down")
         self._pb_move_to_top = PushButtonMinimumWidth("Top")
         self._pb_move_to_bottom = PushButtonMinimumWidth("Bottom")
@@ -836,9 +836,9 @@ class QtRePlanQueue(QWidget):
         # If the selected queue item is not in the table anymore (e.g. sent to execution),
         #   then ignore the drop event, since the item can not be moved.
         if self.model.selected_queue_item_uids:
-            item_uid_to_replace = self.model.queue_item_pos_to_uid(row)
+            uid_ref_item = self.model.queue_item_pos_to_uid(row)
             try:
-                self.model.queue_item_move_in_place_of(item_uid_to_replace)
+                self.model.queue_items_move_in_place_of(uid_ref_item)
             except Exception as ex:
                 print(f"Exception: {ex}")
 
@@ -962,31 +962,31 @@ class QtRePlanQueue(QWidget):
 
     def _pb_move_up_clicked(self):
         try:
-            self.model.queue_item_move_up()
+            self.model.queue_items_move_up()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_down_clicked(self):
         try:
-            self.model.queue_item_move_down()
+            self.model.queue_items_move_down()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_to_top_clicked(self):
         try:
-            self.model.queue_item_move_to_top()
+            self.model.queue_items_move_to_top()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_to_bottom_clicked(self):
         try:
-            self.model.queue_item_move_to_bottom()
+            self.model.queue_items_move_to_bottom()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_delete_plan_clicked(self):
         try:
-            self.model.queue_item_remove()
+            self.model.queue_items_remove()
         except Exception as ex:
             print(f"Exception: {ex}")
 

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -944,12 +944,11 @@ class QtRePlanQueue(QWidget):
             self._block_table_selection_processing = True
             self._table.clearSelection()
             for row in rows:
+                if self._table.currentRow() not in rows:
+                    self._table.setCurrentCell(rows[-1], 0)
                 for col in range(self._table.columnCount()):
                     item = self._table.item(row, col)
                     item.setSelected(True)
-
-            if self._table.currentRow() not in rows:
-                self._table.setCurrentCell(rows[-1], 0)
 
             row_visible = rows[-1]
             item_visible = self._table.item(row_visible, 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaced 'emulated' batch queue operations (add batch of items, move batch of items, remove batch of items) by calls to batch API of RE Manager (0MQ API `queue_item_add_batch`, `queue_item_move_batch`, `queue_item_remove_batch`). Previously the batch API did not exist and were replaced by multiple calls to API that perform operations on the single item. Now batch operations are performed as a single call to batch API. Batch API were implemented in PRs https://github.com/bluesky/bluesky-queueserver/pull/161, https://github.com/bluesky/bluesky-queueserver/pull/164 and https://github.com/bluesky/bluesky-queueserver/pull/165

The PR is not expected to change functionality of the widgets that is exposed to users.


