### PR TITLE
Open item in the Plan Editor widget by double-clicking on the plan

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -898,7 +898,7 @@ class RunEngineClient:
         if not items:
             return
 
-        sel_item_uids = self._selected_queue_item_uids.copy()
+        sel_item_uids = self.selected_queue_item_uids.copy()
 
         if sel_item_uids:
             # Insert after the last item in the selected batch
@@ -937,7 +937,6 @@ class RunEngineClient:
                     f"{pprint.pformat(response)}. Can not update item selection in the queue table. "
                     f"Exception: {ex}"
                 )
-            print(f"sel_item_uids = {sel_item_uids}")  ##
             self.selected_queue_item_uids = sel_item_uids
 
     def queue_upload_spreadsheet(self, *, file_path, data_type=None):

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -725,7 +725,7 @@ class QtRePlanQueue(QWidget):
         self._n_table_items = 0  # The number of items in the table
         self._selected_items_pos = []  # Selected items (list of table rows)
 
-        self._pb_move_up = PushButtonMinimumWidth("Move Up")
+        self._pb_move_up = PushButtonMinimumWidth("Up")
         self._pb_move_down = PushButtonMinimumWidth("Down")
         self._pb_move_to_top = PushButtonMinimumWidth("Top")
         self._pb_move_to_bottom = PushButtonMinimumWidth("Bottom")
@@ -836,9 +836,9 @@ class QtRePlanQueue(QWidget):
         # If the selected queue item is not in the table anymore (e.g. sent to execution),
         #   then ignore the drop event, since the item can not be moved.
         if self.model.selected_queue_item_uids:
-            item_uid_to_replace = self.model.queue_item_pos_to_uid(row)
+            uid_ref_item = self.model.queue_item_pos_to_uid(row)
             try:
-                self.model.queue_item_move_in_place_of(item_uid_to_replace)
+                self.model.queue_items_move_in_place_of(uid_ref_item)
             except Exception as ex:
                 print(f"Exception: {ex}")
 
@@ -962,31 +962,31 @@ class QtRePlanQueue(QWidget):
 
     def _pb_move_up_clicked(self):
         try:
-            self.model.queue_item_move_up()
+            self.model.queue_items_move_up()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_down_clicked(self):
         try:
-            self.model.queue_item_move_down()
+            self.model.queue_items_move_down()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_to_top_clicked(self):
         try:
-            self.model.queue_item_move_to_top()
+            self.model.queue_items_move_to_top()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_move_to_bottom_clicked(self):
         try:
-            self.model.queue_item_move_to_bottom()
+            self.model.queue_items_move_to_bottom()
         except Exception as ex:
             print(f"Exception: {ex}")
 
     def _pb_delete_plan_clicked(self):
         try:
-            self.model.queue_item_remove()
+            self.model.queue_items_remove()
         except Exception as ex:
             print(f"Exception: {ex}")
 

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -658,6 +658,20 @@ class QueueTableWidget(QTableWidget):
         )
         self._scroll_timer.start(timeout)
 
+    def scrollTo(self, index, hint):
+        """
+        Prevent horizontal autoscrolling when clicking on columns that don't fit
+        horizontally within the displayed region of the table. Autoscrolling
+        causes annoying behavor of the table widget. Without it, the table
+        is always scrolled to the left to make the first column visible whenever
+        the row is selected (programmatically or by clicking on the row).
+
+        No significant issues in table behavior were noticed during the brief test.
+        There could be a better solution to resolve the issue.
+        """
+        if hint != QAbstractItemView.EnsureVisible:
+            super().scrollTo(index, hint)
+
 
 class PushButtonMinimumWidth(QPushButton):
     """

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -658,20 +658,6 @@ class QueueTableWidget(QTableWidget):
         )
         self._scroll_timer.start(timeout)
 
-    def scrollTo(self, index, hint):
-        """
-        Prevent horizontal autoscrolling when clicking on columns that don't fit
-        horizontally within the displayed region of the table. Autoscrolling
-        causes annoying behavor of the table widget. Without it, the table
-        is always scrolled to the left to make the first column visible whenever
-        the row is selected (programmatically or by clicking on the row).
-
-        No significant issues in table behavior were noticed during the brief test.
-        There could be a better solution to resolve the issue.
-        """
-        if hint != QAbstractItemView.EnsureVisible:
-            super().scrollTo(index, hint)
-
 
 class PushButtonMinimumWidth(QPushButton):
     """
@@ -724,6 +710,10 @@ class QtRePlanQueue(QWidget):
         self._table.setAcceptDrops(False)
         self._table.setDropIndicatorShown(True)
         self._table.setShowGrid(True)
+
+        # Prevents horizontal autoscrolling when clicking on an item (column) that
+        # doesn't fit horizontally the displayed view of the table (annoying behavior)
+        self._table.setAutoScroll(False)
 
         self._table.setAlternatingRowColors(True)
 
@@ -951,6 +941,9 @@ class QtRePlanQueue(QWidget):
 
         rows = [self.model.queue_item_uid_to_pos(_) for _ in selected_item_uids]
 
+        # Keep horizontal scroll value while the selection is changed (more consistent behavior)
+        scroll_value = self._table.horizontalScrollBar().value()
+
         if not rows:
             self._table.clearSelection()
             self._selected_items_pos = []
@@ -970,6 +963,8 @@ class QtRePlanQueue(QWidget):
             self._block_table_selection_processing = False
 
             self._selected_items_pos = rows
+
+        self._table.horizontalScrollBar().setValue(scroll_value)
 
         self.model.selected_queue_item_uids = selected_item_uids
         self._update_button_states()
@@ -1060,6 +1055,10 @@ class QtRePlanHistory(QWidget):
         self._table.setSelectionMode(QTableWidget.ContiguousSelection)
         self._table.setShowGrid(True)
         self._table.setAlternatingRowColors(True)
+
+        # Prevents horizontal autoscrolling when clicking on an item (column) that
+        # doesn't fit horizontally the displayed view of the table (annoying behavior)
+        self._table.setAutoScroll(False)
 
         self._table.horizontalHeader().setDefaultAlignment(Qt.AlignLeft)
         self._table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
@@ -1217,6 +1216,9 @@ class QtRePlanHistory(QWidget):
     def slot_change_selection(self, selected_item_pos):
         rows = selected_item_pos
 
+        # Keep horizontal scroll value while the selection is changed (more consistent behavior)
+        scroll_value = self._table.horizontalScrollBar().value()
+
         if not rows:
             self._table.clearSelection()
             self._selected_items_pos = []
@@ -1236,6 +1238,8 @@ class QtRePlanHistory(QWidget):
             self._table.scrollToItem(item_visible, QAbstractItemView.EnsureVisible)
             self._block_table_selection_processing = False
             self._selected_items_pos = rows
+
+        self._table.horizontalScrollBar().setValue(scroll_value)
 
         self.model.selected_history_item_pos = selected_item_pos
         self._update_button_states()

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -2081,7 +2081,6 @@ class _QtReEditor(QWidget):
         # self._combo_item_list.setSizePolicy(QComboBox.AdjustToContents)
         self._combo_item_list.currentIndexChanged.connect(self._combo_item_list_sel_changed)
 
-        self._pb_new_item = QPushButton("New")
         self._lb_item_source = QLabel(self._current_item_source)
 
         # Start with 'detailed' view (show optional parameters)
@@ -2096,7 +2095,6 @@ class _QtReEditor(QWidget):
         self._pb_reset = QPushButton("Reset")
         self._pb_cancel = QPushButton("Cancel")
 
-        self._pb_new_item.clicked.connect(self._pb_new_item_clicked)
         self._pb_batch_upload.clicked.connect(self._pb_batch_upload_clicked)
 
         self._pb_add_to_queue.clicked.connect(self._pb_add_to_queue_clicked)
@@ -2112,7 +2110,6 @@ class _QtReEditor(QWidget):
         hbox.addWidget(self._rb_item_instruction)
         hbox.addWidget(self._combo_item_list)
         hbox.addStretch(1)
-        hbox.addWidget(self._pb_new_item)
         hbox.addWidget(self._lb_item_source)
         vbox.addLayout(hbox)
 
@@ -2174,8 +2171,6 @@ class _QtReEditor(QWidget):
         self._rb_item_plan.setEnabled(not self._edit_mode_enabled)
         self._rb_item_instruction.setEnabled(not self._edit_mode_enabled)
         self._combo_item_list.setEnabled(not self._edit_mode_enabled)
-        self._pb_new_item.setEnabled(not self._edit_mode_enabled)
-        self._pb_new_item.setVisible(not self._edit_mode_enabled)
 
         self._pb_batch_upload.setEnabled(is_connected)
 
@@ -2254,14 +2249,6 @@ class _QtReEditor(QWidget):
     def _slot_parameters_valid(self, is_valid):
         self._editor_state_valid = is_valid
         self._update_widget_state()
-
-    def _pb_new_item_clicked(self):
-        item_type = self._current_item_type
-        item_name = self._combo_item_list.currentText()
-        if item_name:
-            new_item = {"item_type": item_type, "name": item_name}
-            self._current_item_source = "NEW ITEM"
-            self._edit_item(new_item)
 
     def _pb_batch_upload_clicked(self):
         dlg = DialogBatchUpload(

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -944,12 +944,11 @@ class QtRePlanQueue(QWidget):
             self._block_table_selection_processing = True
             self._table.clearSelection()
             for row in rows:
+                if self._table.currentRow() not in rows:
+                    self._table.setCurrentCell(rows[-1], 0)
                 for col in range(self._table.columnCount()):
                     item = self._table.item(row, col)
                     item.setSelected(True)
-
-            if self._table.currentRow() not in rows:
-                self._table.setCurrentCell(rows[-1], 0)
 
             row_visible = rows[-1]
             item_visible = self._table.item(row_visible, 0)

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -688,7 +688,7 @@ class QtRePlanQueue(QWidget):
         # Set True to block processing of table selection change events
         self._block_table_selection_processing = False
 
-        self._registered_plan_editors = []
+        self._registered_item_editors = []
 
         # Local copy of the plan queue items for operations performed locally
         #   in the Qt Widget code without calling the model. Using local copy that
@@ -800,25 +800,26 @@ class QtRePlanQueue(QWidget):
 
     @property
     def registered_item_editors(self):
-        return self._registered_plan_editors
-
-    def register_item_editor(self, editor_activator):
         """
-        Add editor to the list of registered plan editors. The function accepts a callable, which
-        accepts dictionary of item parameters as an argument and returns boolean value ``True`` if
-        the editor accepts the item. When user double-clicks the table row, the editors from the list
-        are called one by one until the plan is accepted. The editor that accepted the plan is expected
-        to become active and allow users to change plan parameters. Typically the editors should be
-        registered in the order starting from custom editors designed for editing specific plans
-        proceeding to generic editors that will accept any plan that was rejected by custom editors.
+        Returns reference to the list of registered plan editors. The reference is not editable,
+        but the items can be added or removed from the list using ``append``, ``pop`` and ``clear``
+        methods.
 
-        Parameters
-        ----------
-        editor_activator : callable
-            Callable that accepts the dictionary of item parameters, attempts to open item in
-            the item (plan) editor and returns boolean value if the editor accepted the item.
+        Editors may be added to the list of registered plan editors by inserting/appending reference
+        to a callable. The must accepts dictionary of item parameters as an argument and return
+        boolean value ``True`` if the editor accepts the item. When user double-clicks the table row,
+        the editors from the list are called one by one until the plan is accepted. The first editor
+        that accepts the plan must be activated and allow users to change plan parameters. Typically
+        the editors should be registered in the order starting from custom editors designed for
+        editing specific plans proceeding to generic editors that will accept any plan that was
+        rejected by custom editors.
+
+        Returns
+        -------
+        list(callable)
+            List of references to registered editors. List is empty if no editors are registered.
         """
-        self._registered_plan_editors.append(editor_activator)
+        return self._registered_item_editors
 
     def on_update_widgets(self, event):
         # None should be converted to False:

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -2184,6 +2184,10 @@ class _QtReEditor(QWidget):
         self._lb_item_source.setText(self._current_item_source)
 
     def edit_queue_item(self, queue_item):
+        """
+        Calling this function while another plan is being edited will cancel editing, discard results
+        and open another plan for editing.
+        """
         self._current_item_source = "QUEUE ITEM"
         self._edit_item(queue_item)
 
@@ -2213,6 +2217,7 @@ class _QtReEditor(QWidget):
     def _switch_to_editing_mode(self):
         if not self._edit_mode_enabled:
             self._edit_mode_enabled = True
+            self._current_item_source = "NEW ITEM"
             self._update_widget_state()
 
     def _show_item_preview(self):

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -32,7 +32,7 @@ from qtpy.QtCore import Qt, Signal, Slot, QTimer
 from qtpy.QtGui import QFontMetrics, QPalette, QBrush, QColor
 
 from bluesky_widgets.qt.threading import FunctionWorker
-from bluesky_queueserver.manager.profile_ops import _construct_parameters
+from bluesky_queueserver.manager.profile_ops import construct_parameters
 
 
 class LineEditExtended(QLineEdit):
@@ -1632,9 +1632,7 @@ class _QtRePlanEditorTable(QTableWidget):
         # print(f"plan_params={pprint.pformat(plan_params)}")
         if item_editable:
             # Construct parameters (list of inspect.Parameter objects)
-            parameters, created_type_list = _construct_parameters(item_params.get("parameters", {}))
-            # print(f"parameters = {parameters}")
-            # print(f"default = {[_.default for _ in parameters]}")
+            parameters = construct_parameters(item_params.get("parameters", {}))
         else:
             parameters = []
             for key, val in item_kwargs.items():

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -1451,6 +1451,8 @@ class _QtRePlanEditorTable(QTableWidget):
 
     signal_parameters_valid = Signal(bool)
     signal_item_description_changed = Signal(str)
+    # The following signal is emitted only if the cell manually modified
+    signal_cell_modified = Signal()
 
     def __init__(self, model, parent=None, *, editable=False, detailed=True):
         super().__init__(parent)
@@ -1461,6 +1463,7 @@ class _QtRePlanEditorTable(QTableWidget):
         self._text_color_invalid = QBrush(QColor(255, 0, 0))
 
         self._validation_disabled = False
+        self._enable_signal_cell_modified = True
 
         self._queue_item = None  # Copy of the displayed queue item
         self._params = []
@@ -1733,6 +1736,7 @@ class _QtRePlanEditorTable(QTableWidget):
                 return str(v)
 
         self._validation_disabled = True
+        self._enable_signal_cell_modified = False
         self.clearContents()
 
         params = self._params
@@ -1811,6 +1815,7 @@ class _QtRePlanEditorTable(QTableWidget):
 
         self._validation_disabled = False
         self._validate_cell_values()
+        self._enable_signal_cell_modified = True
 
     def show_item(self, *, item, editable=None):
         if editable is not None:
@@ -1891,10 +1896,15 @@ class _QtRePlanEditorTable(QTableWidget):
                         self._params[row]["value"] = self._params[row]["parameters"].default
 
                     self._params[row]["is_value_set"] = is_checked
-                    self._show_row_value(row=row)
 
-            elif column == 2:
+                    self._enable_signal_cell_modified = False
+                    self._show_row_value(row=row)
+                    self._enable_signal_cell_modified = True
+
+            if column in (1, 2):
                 self._validate_cell_values()
+                if self._enable_signal_cell_modified:
+                    self.signal_cell_modified.emit()
         except ValueError:
             pass
 
@@ -2054,8 +2064,10 @@ class _QtReEditor(QWidget):
         self._current_instruction_name = ""
         self._current_item_source = ""  # Values: "", "NEW ITEM", "QUEUE ITEM"
 
-        self._queue_item_loaded = False
+        self._edit_mode_enabled = False
         self._editor_state_valid = False
+
+        self._ignore_combo_item_list_sel_changed = False
 
         self._rb_item_plan = QRadioButton("Plan")
         self._rb_item_plan.setChecked(True)
@@ -2076,6 +2088,7 @@ class _QtReEditor(QWidget):
         self._wd_editor = _QtRePlanEditorTable(self.model, editable=False, detailed=True)
         self._wd_editor.signal_parameters_valid.connect(self._slot_parameters_valid)
         self._wd_editor.signal_item_description_changed.connect(self._slot_item_description_changed)
+        self._wd_editor.signal_cell_modified.connect(self._switch_to_editing_mode)
 
         self._pb_batch_upload = QPushButton("Batch Upload")
         self._pb_add_to_queue = QPushButton("Add to Queue")
@@ -2158,11 +2171,11 @@ class _QtReEditor(QWidget):
 
         is_connected = bool(self.model.re_manager_connected)
 
-        self._rb_item_plan.setEnabled(not self._queue_item_loaded)
-        self._rb_item_instruction.setEnabled(not self._queue_item_loaded)
-        self._combo_item_list.setEnabled(not self._queue_item_loaded)
-        self._pb_new_item.setEnabled(not self._queue_item_loaded)
-        self._pb_new_item.setVisible(not self._queue_item_loaded)
+        self._rb_item_plan.setEnabled(not self._edit_mode_enabled)
+        self._rb_item_instruction.setEnabled(not self._edit_mode_enabled)
+        self._combo_item_list.setEnabled(not self._edit_mode_enabled)
+        self._pb_new_item.setEnabled(not self._edit_mode_enabled)
+        self._pb_new_item.setVisible(not self._edit_mode_enabled)
 
         self._pb_batch_upload.setEnabled(is_connected)
 
@@ -2170,8 +2183,8 @@ class _QtReEditor(QWidget):
         self._pb_save_item.setEnabled(
             self._editor_state_valid and is_connected and self._current_item_source == "QUEUE ITEM"
         )
-        self._pb_reset.setEnabled(self._queue_item_loaded)
-        self._pb_cancel.setEnabled(self._queue_item_loaded)
+        self._pb_reset.setEnabled(self._edit_mode_enabled)
+        self._pb_cancel.setEnabled(self._edit_mode_enabled)
 
         self._lb_item_source.setText(self._current_item_source)
 
@@ -2179,7 +2192,7 @@ class _QtReEditor(QWidget):
         self._current_item_source = "QUEUE ITEM"
         self._edit_item(queue_item)
 
-    def _edit_item(self, queue_item):
+    def _edit_item(self, queue_item, *, edit_mode=True):
         self._queue_item_name = queue_item.get("name", None)
         self._queue_item_type = queue_item.get("item_type", None)
 
@@ -2192,11 +2205,19 @@ class _QtReEditor(QWidget):
                 self._current_plan_name = self._queue_item_name
                 self._rb_item_plan.setChecked(True)
 
+            self._ignore_combo_item_list_sel_changed = True
             self._set_allowed_item_list()
+            self._ignore_combo_item_list_sel_changed = False
 
             self._wd_editor.show_item(item=queue_item, editable=True)
 
-            self._queue_item_loaded = True
+            self._edit_mode_enabled = bool(edit_mode)
+            self._update_widget_state()
+
+    @Slot()
+    def _switch_to_editing_mode(self):
+        if not self._edit_mode_enabled:
+            self._edit_mode_enabled = True
             self._update_widget_state()
 
     def _show_item_preview(self):
@@ -2207,7 +2228,7 @@ class _QtReEditor(QWidget):
         item_type = self._current_item_type
         if item_name:
             item = {"item_type": item_type, "name": item_name}
-            self._wd_editor.show_item(item=item, editable=False)
+            self._edit_item(queue_item=item, edit_mode=False)
 
     def _save_selected_item_name(self):
         item_name = self._combo_item_list.currentText()
@@ -2266,7 +2287,7 @@ class _QtReEditor(QWidget):
             self.model.queue_item_add(item=item)
             self._wd_editor.show_item(item=None)
             self.signal_switch_tab.emit("view")
-            self._queue_item_loaded = False
+            self._edit_mode_enabled = False
             self._current_item_source = ""
             self._update_widget_state()
             self._show_item_preview()
@@ -2283,7 +2304,7 @@ class _QtReEditor(QWidget):
             self.model.queue_item_update(item=item)
             self._wd_editor.show_item(item=None)
             self.signal_switch_tab.emit("view")
-            self._queue_item_loaded = False
+            self._edit_mode_enabled = False
             self._current_item_source = ""
             self._update_widget_state()
             self._show_item_preview()
@@ -2298,7 +2319,7 @@ class _QtReEditor(QWidget):
 
     def _pb_cancel_clicked(self):
         self._wd_editor.show_item(item=None)
-        self._queue_item_loaded = False
+        self._edit_mode_enabled = False
         self._queue_item_type = ""
         self._queue_item_name = ""
         self._current_item_source = ""
@@ -2318,7 +2339,7 @@ class _QtReEditor(QWidget):
         self._save_selected_item_name()
         # We don't process the case when the list of allowed plans changes and the selected
         #   item is not in the list. But this is not a practical case.
-        if not self._queue_item_loaded:
+        if not self._ignore_combo_item_list_sel_changed:
             self._show_item_preview()
 
     def _on_allowed_plans_changed(self, allowed_plans):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improvement of user productivity by implementing easier way for opening items in the editor. Originally, the only way to open existing queue item for editing was to select item in the Plan Queue Widget and then click 'Edit' button in the Plan Viewer
tab of the editor. Changes in this PR allow to open an item in the Plan Editor by double-clicking the item in the Plan Queue Widget. This may improve productivity when small adjustments of parameters need to be done for many plans in a row (e.g. if workflow includes duplication of a plan multiple times and then setting plan parameters).

If an item is open for editing, then double-clicking on a different plan will cancel editing of currently opened plan, discard changes and open the other plan for editing. Since plan editing is expected to be trivial, it makes sense to allow easy switching between plans by reducing the number of clicks as opposed to protecting results of editing by preventing automatic cancelling of the plans that are being edited. The configurable option that allows to select if changes need to be protected may be added in the future.

## Description
<!--- Describe your changes in detail -->
In order to enable functionality, the editors must be registered with the Plan Queue Widget (see ``QtRePlanQueue.register_item_editor()``). If multiple editors are used, they need to be registered in the order starting from custom editors proceeding to general-purpose editors that will accept all plans rejected by custom editors. Once the item is double-clicked, the item is opened in the first editor that accepts it. If no editors are registered, then double-click event is ignored.

The feature is implemented purely in Qt without involving the underlying model. If multiple instances of Plan Queue widgets are used in the application, each of the instances may be calling different set of registered editors (typically editors would be located in the same window as the Plan Queue widget and some windows may not have editors).

Addresses issue https://github.com/bluesky/bluesky-widgets/issues/139

## Motivation and Context
The feature was requested by @DanOlds