### PR TITLE
PERF: Convert zmq dispatcher LOADING_LATENCY to msec

### DIFF
--- a/bluesky_widgets/qt/zmq_dispatcher.py
+++ b/bluesky_widgets/qt/zmq_dispatcher.py
@@ -7,7 +7,7 @@ from ..qt.threading import create_worker
 from qtpy.QtCore import QTimer, QObject
 
 
-LOADING_LATENCY = 10 # msec
+LOADING_LATENCY = 10  # msec
 
 
 class RemoteDispatcher(QObject):

--- a/bluesky_widgets/qt/zmq_dispatcher.py
+++ b/bluesky_widgets/qt/zmq_dispatcher.py
@@ -7,7 +7,7 @@ from ..qt.threading import create_worker
 from qtpy.QtCore import QTimer, QObject
 
 
-LOADING_LATENCY = 0.01
+LOADING_LATENCY = 10 # msec
 
 
 class RemoteDispatcher(QObject):
@@ -58,7 +58,6 @@ class RemoteDispatcher(QObject):
         self._socket.setsockopt_string(zmq.SUBSCRIBE, "")
         self._task = None
         self.closed = False
-        self._timer = QTimer(self)
         self._dispatcher = Dispatcher()
         self.subscribe = self._dispatcher.subscribe
         self._waiting_for_start = True
@@ -104,7 +103,7 @@ class RemoteDispatcher(QObject):
             self._receive_data,
         )
         # Schedule this method to be run again after a brief wait.
-        worker.finished.connect(lambda: self._timer.singleShot(LOADING_LATENCY, self._work_loop))
+        worker.finished.connect(lambda: QTimer.singleShot(LOADING_LATENCY, self._work_loop))
         worker.yielded.connect(self._process_result)
         worker.start()
 

--- a/bluesky_widgets/qt/zmq_dispatcher.py
+++ b/bluesky_widgets/qt/zmq_dispatcher.py
@@ -1,4 +1,5 @@
 import pickle
+import time
 
 from bluesky.run_engine import Dispatcher, DocumentNames
 import zmq
@@ -7,7 +8,7 @@ from ..qt.threading import create_worker
 from qtpy.QtCore import QTimer, QObject
 
 
-LOADING_LATENCY = 10  # msec
+LOADING_LATENCY = 0.01  # sec
 
 
 class RemoteDispatcher(QObject):
@@ -69,9 +70,13 @@ class RemoteDispatcher(QObject):
             try:
                 message = self._socket.recv(zmq.NOBLOCK)
             except zmq.ZMQError:
-                break
+                time.sleep(LOADING_LATENCY)
+                yield
+                continue
             if not message:
-                break
+                time.sleep(LOADING_LATENCY)
+                yield
+                continue
             prefix, name, doc = message.split(b" ", 2)
             name = name.decode()
             if (not our_prefix) or prefix == our_prefix:
@@ -82,7 +87,9 @@ class RemoteDispatcher(QObject):
                         # We subscribed midstream and are seeing documents for
                         # which we do not have the full run. Wait for a 'start'
                         # doc.
-                        return
+                        time.sleep(LOADING_LATENCY)
+                        yield
+                        continue
                 doc = self._deserializer(doc)
             yield name, doc
 
@@ -103,7 +110,7 @@ class RemoteDispatcher(QObject):
             self._receive_data,
         )
         # Schedule this method to be run again after a brief wait.
-        worker.finished.connect(lambda: QTimer.singleShot(LOADING_LATENCY, self._work_loop))
+        worker.finished.connect(lambda: QTimer.singleShot(int(LOADING_LATENCY * 1000), self._work_loop))
         worker.yielded.connect(self._process_result)
         worker.start()
 


### PR DESCRIPTION
Had been getting high CPU usage and ballooning memory usage ultimately causing the OS to kill my application. Changing this one number fixed that. It is documented as an integer in msec, so a value of 0.01 does not make sense

Additionally singleShot is a staticmethod and so does not need to be called on an instance of QTimer


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[PyQT5's docs](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qtimer.html?highlight=qtimer#singleShot) are woefully incomplete here, but do indicate the type is int and the static method.

[PySide2's docs](
https://doc.qt.io/qtforpython-5/PySide2/QtCore/QTimer.html#PySide2.QtCore.PySide2.QtCore.QTimer.singleShot) tell the same story, but with at least more info on the other forms of the method signature, if not the one we _actually_ use...

## How Has This Been Tested?
Running an app using the ZMQ Dispatcher, watching memory usage rise (and CPU usage remain higher than expected at 100% of one core)

After changing memory remained under 1% and stable, CPU was around 10% (still perhaps a bit higher than I'd like, but acceptable)

<!--
## Screenshots (if appropriate):
-->
