### PR TITLE
Minor fix in editor widget to support plans with parameters represented only by 'args' or 'kwargs'

### DIFF
--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -1697,7 +1697,7 @@ class _QtRePlanEditorTable(QTableWidget):
 
         # Collect 'args'
         args = []
-        if n_var_pos > 0:
+        if n_var_pos >= 0:
             if not isinstance(params[n_var_pos]["value"], (list, tuple)):
                 raise ValueError(f"Invalid type of VAR_POSITIONAL argument: {params[n_var_pos]['value']}")
             for n in range(n_var_pos):
@@ -1714,7 +1714,7 @@ class _QtRePlanEditorTable(QTableWidget):
             if params[n]["is_value_set"] and (params[n]["value"] != inspect.Parameter.empty):
                 kwargs[params[n]["parameters"].name] = params[n]["value"]
 
-        if n_var_kwd > 0:
+        if n_var_kwd >= 0:
             if not isinstance(params[n_var_kwd]["value"], dict):
                 raise ValueError(f"Invalid type of VAR_KEYWORD argument: {params[n_var_kwd]['value']}")
             kwargs.update(params[n_var_kwd]["value"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Minor fix for a bug that prevented submitting `mv` and `mvr` plans using plan editor widgets. The bug prevented plans similar to

```
def plan_args(*args):
     <code>

def plan_kwargs(**kwargs):
    <code>
```

from being submitted correctly.