### PR TITLE
Minor fixes in examples

### DIFF
--- a/bluesky_widgets/examples/headless_figures.py
+++ b/bluesky_widgets/examples/headless_figures.py
@@ -12,7 +12,7 @@ from bluesky.plans import scan
 from ophyd.sim import motor, det
 
 from bluesky_widgets.utils.streaming import stream_documents_into_runs
-from bluesky_widgets.models.plot_builders import AutoLines
+from bluesky_widgets.models.auto_plot_builders import AutoLines
 from bluesky_widgets.headless.figures import HeadlessFigures
 from bluesky_widgets.examples.utils.generate_msgpack_data import get_catalog
 

--- a/bluesky_widgets/examples/napari_dock_widgets.py
+++ b/bluesky_widgets/examples/napari_dock_widgets.py
@@ -101,6 +101,7 @@ class NapariDatabroker(napari.Viewer):
 
 with napari.gui_qt():
     viewer = NapariDatabroker()
+    viewer.grid.enabled = True
     viewer.window.add_dock_widget(QtSearchListWithButton(viewer.searches), area="right")
 
     # Initialize with a two search tabs: one with some generated example data...

--- a/bluesky_widgets/examples/napari_dock_widgets.py
+++ b/bluesky_widgets/examples/napari_dock_widgets.py
@@ -101,7 +101,6 @@ class NapariDatabroker(napari.Viewer):
 
 with napari.gui_qt():
     viewer = NapariDatabroker()
-    viewer.grid_view()  # Place images side by side, not stacked.
     viewer.window.add_dock_widget(QtSearchListWithButton(viewer.searches), area="right")
 
     # Initialize with a two search tabs: one with some generated example data...

--- a/bluesky_widgets/examples/pyFAI_dialog.py
+++ b/bluesky_widgets/examples/pyFAI_dialog.py
@@ -863,8 +863,8 @@ def main():
     # Begin modifications for bluesky_widgets
 
     from qtpy.QtWidgets import QDialog
-    from bluesky_widgets.models.search.searches import Search
-    from bluesky_widgets.qt.searches import QtSearch
+    from bluesky_widgets.models.search import Search
+    from bluesky_widgets.qt.search import QtSearch
     from bluesky_widgets.examples.utils.generate_msgpack_data import get_catalog
     from bluesky_widgets.examples.utils.add_search_mixin import columns
 


### PR DESCRIPTION
## Description
Two examples in the repo fail due to wrong import paths.
A third example (napari_dock_widgets) uses a method deprecated in napari 0.4.4


## How Has This Been Tested?
Recent conda packages from conda-forge and nsls2forge channels.
Note that Napari v0.4.5 was used, due to compatibility errors starting at napari 0.4.6 caused by the introduction of _pydantic_, see [napari changelog](https://napari.org/release/release_0_4_6.html).
