### PR TITLE
Keep AutoLines._lines_instances dict up to date with figures/plot_builders lists

### DIFF
--- a/bluesky_widgets/models/auto_plot_builders/_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_lines.py
@@ -26,6 +26,7 @@ class AutoLines(AutoPlotter):
         # Map (stream_name, x, tuple_of_tuple_of_ys) to line of Lines instances for each group of y.
         self._lines_instances = {}
         self._max_runs = max_runs
+        self.figures.events.removed.connect(self._on_figure_removed)
 
     @property
     def max_runs(self):
@@ -38,6 +39,15 @@ class AutoLines(AutoPlotter):
                 for builder in builders:
                     builder.max_runs = value
         self._max_runs = value
+
+    def _on_figure_removed(self, event):
+        super()._on_figure_removed(event)
+        figure = event.item
+        for key, plot_builders in self._lines_instances.items():
+            for plot_builder in plot_builders:
+                if figure == plot_builder.figure:
+                    key_to_remove = key
+        self._lines_instances.pop(key_to_remove)
 
     def handle_new_stream(self, run, stream_name, **kwargs):
         """

--- a/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
@@ -84,3 +84,5 @@ def test_removed_figures():
     model.add_run(runs[0])
     assert len(model.plot_builders) == 3
     assert len(model.figures) == 1
+
+    view.close()

--- a/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_tests/test_auto_lines.py
@@ -67,3 +67,20 @@ def test_decrease_max_runs():
     assert len(model.figures[0].axes[0].artists) == MAX_RUNS
 
     view.close()
+
+
+def test_removed_figures():
+    "Test that a new figure is created after closing a tab/removing a figure."
+    model = AutoLines(max_runs=MAX_RUNS)
+    view = HeadlessFigures(model.figures)
+    model.add_run(runs[0])  # One figure, 3 plot_builders
+    assert len(model.plot_builders) == 3
+    assert len(model.figures) == 1
+    # Remove the figure. No figures or plot_builders should be left.
+    del model.figures[0]
+    assert len(model.plot_builders) == 0
+    assert len(model.figures) == 0
+    # Add the runs back and a new figure should be created.
+    model.add_run(runs[0])
+    assert len(model.plot_builders) == 3
+    assert len(model.figures) == 1


### PR DESCRIPTION
## Description
`AutoLines` now has a function (`on_figure_removed`) that updates the `_lines_instances` dict when a figure is removed or a tab is closed.

## Motivation and Context
The `AutoLines._line_instances` dict is not updated after closing a figure, so no new figures are created after closing out all the figures and adding another run.

## How Has This Been Tested?
Tested interactively by using `AutoLines` to plot a scan, closing the tab, and rerunning the scan.