### PR TITLE
Plot time relative to the start of the run

### DIFF
--- a/bluesky_widgets/models/utils.py
+++ b/bluesky_widgets/models/utils.py
@@ -94,13 +94,17 @@ def construct_namespace(run, stream_names):
     """
     namespace = dict(_base_namespace)  # shallow copy
     with lock_if_live(run):
+        run_start_time = run.metadata["start"]["time"]
         # Add columns from streams in stream_names. Earlier entries will get
         # precedence.
         for stream_name in reversed(stream_names):
             ds = run[stream_name].to_dask()
             namespace.update({column: ds[column] for column in ds})
             namespace.update({column: ds[column] for column in ds.coords})
+        namespace["time"] = namespace["time"] - run_start_time
         namespace.update({stream_name: run[stream_name].to_dask() for stream_name in stream_names})
+        for stream_name in stream_names:
+            namespace[stream_name]["time"] = namespace[stream_name]["time"] - run_start_time
     namespace.update({"run": run})
     return namespace
 

--- a/bluesky_widgets/models/utils.py
+++ b/bluesky_widgets/models/utils.py
@@ -101,7 +101,8 @@ def construct_namespace(run, stream_names):
             ds = run[stream_name].to_dask()
             namespace.update({column: ds[column] for column in ds})
             namespace.update({column: ds[column] for column in ds.coords})
-        namespace["time"] = namespace["time"] - run_start_time
+        if "time" in namespace:
+            namespace["time"] = namespace["time"] - run_start_time
         namespace.update({stream_name: run[stream_name].to_dask() for stream_name in stream_names})
         for stream_name in stream_names:
             namespace[stream_name]["time"] = namespace[stream_name]["time"] - run_start_time


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The run start time is subtracted from all times in the run so that anything plotted vs `time` shows the time relative to the start of the run instead of seconds since 1970 (the UNIX epoch).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #156.

## How Has This Been Tested?
Tested interactively by plotting the results of `bp.count` on simulated detectors.

## Screenshots:
![time_plot](https://user-images.githubusercontent.com/35899293/139745275-a36f9d23-cc42-40ec-ab9a-98c449b3f8b3.png)
