### PR TITLE
GUI components for selecting additional parameters for processing of custom spreadsheets

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -816,7 +816,8 @@ class RunEngineClient:
                 )
             self.selected_queue_item_uids = sel_item_uids
 
-    def queue_upload_spreadsheet(self, *, file_path, data_type=None):
+    def queue_upload_spreadsheet(self, *, file_path, data_type=None, **kwargs):
+        # ``kwargs``` are passed to the custom spreadsheet processing function
         # TODO: significant part of this function is duplication of the code from
         #   ``bluesky_queueserver.server.server``. Implement reusable function as part of
         #   Queue Server API.
@@ -849,7 +850,7 @@ class RunEngineClient:
                 # Try applying  the custom processing function. Some additional useful data is passed to
                 #   the function. Unnecessary parameters can be ignored.
                 item_list = custom_code_module.spreadsheet_to_plan_list(
-                    spreadsheet_file=f, file_name=f_name, data_type=data_type, user=self._user_name
+                    spreadsheet_file=f, file_name=f_name, data_type=data_type, user=self._user_name, **kwargs
                 )
                 # The function is expected to return None if it rejects the file (based on 'data_type').
                 #   Then try to apply the default processing function.

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -833,6 +833,7 @@ class RunEngineClient:
         with open(file_path, "rb") as f:
             custom_code_module_name = self.qserver_custom_module_name
 
+            custom_code_module = None
             if custom_code_module_name:
                 try:
                     print(f"Importing custom module '{custom_code_module_name}' ...")
@@ -841,7 +842,6 @@ class RunEngineClient:
                     print(f"Module '{custom_code_module_name}' was imported successfully.")
                     # logger.info("Module '%s' was imported successfully.", custom_code_module_name)
                 except Exception as ex:
-                    custom_code_module = None
                     print(f"Failed to import custom instrument module '{custom_code_module_name}': {ex}")
                     # logger.error("Failed to import custom instrument module '%s':
                     # %s", custom_code_module_name, ex)

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -74,6 +74,10 @@ class RunEngineClient:
         self.qserver_custom_module_name = None
         # List of spreadsheet data types
         self.plan_spreadsheet_data_types = None
+        # Dictionary of additional parameters: key - parameter name, value - a dictionary with
+        #   the following key/value pairs: "text" - text description of the parameter to use in the form,
+        #   "values" -  a list or a tuple of values, "type" - type of the value.
+        self.plan_spreadsheet_additional_parameters = {}
 
         # TODO: in the future the list of allowed instructions should be requested from the server
         self._allowed_instructions = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some custom functions for generating lists of plans from custom beamline-specific spreadsheets may require additional parameters. The code in this PR may be used to set the list and descriptions of parameters during model initialization. If parameters are provided, the dialog box for selecting spreadsheet file also contains additional widgets for setting the values of the parameters. Currently the widgets are organized using `QFormLayout` and contain labels with parameter descriptions and combo boxes for selection of values (the values are provided as part of parameter descriptions). This capability may be extended to include text boxes for entering parameter values if needed.

This PR is essential for the experiment at RSOXS on Nov. 4.

## How Has This Been Tested?

The added functionality was tested manually while working on https://github.com/NSLS-II-SST/rsoxs-gui/pull/3

<!--
## Screenshots (if appropriate):
-->
The following screenshot represents a dialog box with custom parameters required by RSOXS-GUI.

![image](https://user-images.githubusercontent.com/46980826/139871677-51eead4b-72f9-463b-8aac-ab9e1728770b.png)

