### PR TITLE
Update python testing versions in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         pip-selectors: ["pyqt5"]
 
       fail-fast: false


### PR DESCRIPTION
Dropping python 3.6 and adding 3.9 and 3.10