### PR TITLE
added check for baseline stream in for live line plotting

### DIFF
--- a/bluesky_widgets/models/auto_plot_builders/_lines.py
+++ b/bluesky_widgets/models/auto_plot_builders/_lines.py
@@ -178,43 +178,45 @@ class AutoLines(AutoPlotter):
 
         if ndims == 1:
             (x_key,) = dim_fields
-            key = (stream_name, x_key, (tuple(columns),))
-            try:
-                lines_instances = self._lines_instances[key]
-            except KeyError:
-                lines_instances = []
-                axes_list = []
-                for y_key in columns:
-                    dtype = descriptor["data_keys"][y_key]["dtype"]
-                    if dtype not in ("number", "integer"):
-                        warn("Omitting {} from plot because dtype is {}" "".format(y_key, dtype))
-                        continue
-                    axes = Axes(x_label=x_key, title=y_key)
-                    axes_list.append(axes)
-                    lines_kwargs = {}
-                    if self.max_runs is not None:
-                        lines_kwargs["max_runs"] = self.max_runs
-                    lines = Lines(
-                        x=x_key,
-                        ys=(y_key,),
-                        needs_streams=(stream_name,),
-                        axes=axes,
-                        **lines_kwargs,
-                    )
-                    lines_instances.append(lines)
-                if not axes_list:
-                    return
-                title = ", ".join((str(lines.ys[0]) for lines in lines_instances)) + f" vs. {x_key}"
-                if len(title) > 15:
-                    short_title = title[:15] + "..."
-                else:
-                    short_title = title
-                figure = Figure(axes_list, title=title, short_title=short_title)
-                self._lines_instances[key] = lines_instances
-                self.plot_builders.extend(lines_instances)
-                self.figures.append(figure)
-            for lines in lines_instances:
-                lines.add_run(run, **kwargs)
+            if stream_name != 'baseline':
+
+                key = (stream_name, x_key, (tuple(columns),))
+                try:
+                    lines_instances = self._lines_instances[key]
+                except KeyError:
+                    lines_instances = []
+                    axes_list = []
+                    for y_key in columns:
+                        dtype = descriptor["data_keys"][y_key]["dtype"]
+                        if dtype not in ("number", "integer"):
+                            warn("Omitting {} from plot because dtype is {}" "".format(y_key, dtype))
+                            continue
+                        axes = Axes(x_label=x_key, title=y_key)
+                        axes_list.append(axes)
+                        lines_kwargs = {}
+                        if self.max_runs is not None:
+                            lines_kwargs["max_runs"] = self.max_runs
+                        lines = Lines(
+                            x=x_key,
+                            ys=(y_key,),
+                            needs_streams=(stream_name,),
+                            axes=axes,
+                            **lines_kwargs,
+                        )
+                        lines_instances.append(lines)
+                    if not axes_list:
+                        return
+                    title = ", ".join((str(lines.ys[0]) for lines in lines_instances)) + f" vs. {x_key}"
+                    if len(title) > 15:
+                        short_title = title[:15] + "..."
+                    else:
+                        short_title = title
+                    figure = Figure(axes_list, title=title, short_title=short_title)
+                    self._lines_instances[key] = lines_instances
+                    self.plot_builders.extend(lines_instances)
+                    self.figures.append(figure)
+                for lines in lines_instances:
+                    lines.add_run(run, **kwargs)
 
         elif ndims == 2:
             return []


### PR DESCRIPTION

## Description
The only change I have made is to add an if statement which checks whether the stream that is to be plotted has name `baseline` if it does, no new plot is made. 

## Motivation and Context
Aiming to solve problem where if a run is performed which contains baseline and primary (and maybe other plans) we don't really want to plot the baseline measurement. This can contain a lot of readings (=lines) that we don't really want to see in the plot

![image](https://user-images.githubusercontent.com/44977769/140781103-83bdaa3f-611e-4434-af4f-01c5c81b1ebe.png)


## How Has This Been Tested?
I have only tested this by loading the widget using Jupyter and creating a run which has baseline and primary streams. I initially attempted to create a test in the pytests file but found that I couldn't use the `build_simple_run` function which was used in those tests because it only has one stream. The `RunBuilder()` would work, but I couldn't work out how to add incremeneting `scan_id` 


