### PR TITLE
Demo application: queue-monitor

### DIFF
--- a/bluesky_widgets/apps/queue_monitor/main.py
+++ b/bluesky_widgets/apps/queue_monitor/main.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+
+from bluesky_widgets.qt import gui_qt
+
+from .viewer import Viewer
+from .settings import SETTINGS
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="BlueSky Queue Monitor")
+    parser.add_argument(
+        "--zmq-control",
+        help="Address of control socket of RE Manager. If the address "
+        "is passed as a CLI parameter, it overrides the address specified with "
+        "QSERVER_ZMQ_CONTROL_ADDRESS environment variable.",
+    )
+    parser.add_argument(
+        "--zmq-publish",
+        help="Address of PUB-SUB socket of RE Manager. If the address "
+        "is passed as a CLI parameter, it overrides the address specified with "
+        "QSERVER_ZMQ_PUBLISH_ADDRESS environment variable.",
+    )
+    args = parser.parse_args(argv)
+
+    # The priority is first to check if an address is passed as a parameter and then
+    #   check if the environment variables are set. Otherwise use the default local addresses.
+    #   (The default addresses are typically used in demos.)
+    zmq_control = args.zmq_control or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
+    zmq_publish = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
+    SETTINGS.zmq_re_manager_control_addr = zmq_control
+    SETTINGS.zmq_re_manager_publish_addr = zmq_publish
+
+    with gui_qt("BlueSky Queue Monitor"):
+        viewer = Viewer()  # noqa: 401
+
+
+if __name__ == "__main__":
+    main()

--- a/bluesky_widgets/apps/queue_monitor/settings.py
+++ b/bluesky_widgets/apps/queue_monitor/settings.py
@@ -1,0 +1,6 @@
+class Settings:
+    zmq_re_manager_control_addr = None
+    zmq_re_manager_publish_addr = None
+
+
+SETTINGS = Settings()

--- a/bluesky_widgets/apps/queue_monitor/viewer.py
+++ b/bluesky_widgets/apps/queue_monitor/viewer.py
@@ -1,0 +1,43 @@
+from bluesky_widgets.models.run_engine_client import RunEngineClient
+from bluesky_widgets.qt import Window
+
+from .widgets import QtViewer
+from .settings import SETTINGS
+
+
+class ViewerModel:
+    """
+    This encapsulates on the models in the application.
+    """
+
+    def __init__(self):
+        self.run_engine = RunEngineClient(
+            zmq_server_address=SETTINGS.zmq_re_manager_control_addr,
+            zmq_subscribe_address=SETTINGS.zmq_re_manager_publish_addr,
+        )
+
+
+class Viewer(ViewerModel):
+    """
+    This extends the model by attaching a Qt Window as its view.
+
+    This object is meant to be exposed to the user in an interactive console.
+    """
+
+    def __init__(self, *, show=True, title="Demo App"):
+        # TODO Where does title thread through?
+        super().__init__()
+        widget = QtViewer(self)
+        self._window = Window(widget, show=show)
+
+    @property
+    def window(self):
+        return self._window
+
+    def show(self):
+        """Resize, show, and raise the window."""
+        self._window.show()
+
+    def close(self):
+        """Close the window."""
+        self._window.close()

--- a/bluesky_widgets/apps/queue_monitor/widgets.py
+++ b/bluesky_widgets/apps/queue_monitor/widgets.py
@@ -1,0 +1,136 @@
+"""
+Extendeding and supplementing the widgets import bluesky-widgets
+"""
+from bluesky_widgets.qt.run_engine_client import (
+    QtReEnvironmentControls,
+    QtReManagerConnection,
+    QtReQueueControls,
+    QtReExecutionControls,
+    QtReStatusMonitor,
+    QtRePlanQueue,
+    QtRePlanHistory,
+    QtReRunningPlan,
+    QtRePlanEditor,
+    QtReConsoleMonitor,
+)
+from qtpy.QtWidgets import (
+    QWidget,
+    QHBoxLayout,
+    QVBoxLayout,
+    QTabWidget,
+    QFrame,
+    QSplitter,
+)
+from qtpy.QtCore import Qt
+
+
+class QtOrganizeQueueWidgets(QSplitter):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        self.setOrientation(Qt.Vertical)
+
+        self._frame_1 = QFrame(self)
+        self._frame_2 = QFrame(self)
+        self._frame_3 = QFrame(self)
+        self._frame_4 = QFrame(self)
+
+        self.addWidget(self._frame_1)
+        self.addWidget(self._frame_2)
+        self.addWidget(self._frame_3)
+        self.addWidget(self._frame_4)
+
+        self._running_plan = QtReRunningPlan(model)
+        self._running_plan.monitor_mode = True
+        self._plan_queue = QtRePlanQueue(model)
+        self._plan_queue.monitor_mode = True
+        self._plan_history = QtRePlanHistory(model)
+        self._plan_history.monitor_mode = True
+        self._console_monitor = QtReConsoleMonitor(model)
+
+        vbox = QVBoxLayout()
+        vbox.setContentsMargins(0, 0, 0, 0)
+        vbox.addWidget(self._running_plan)
+        self._frame_1.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.setContentsMargins(0, 0, 0, 0)
+        vbox.addWidget(self._plan_queue)
+        self._frame_2.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.setContentsMargins(0, 0, 0, 0)
+        vbox.addWidget(self._plan_history)
+        self._frame_3.setLayout(vbox)
+
+        vbox = QVBoxLayout()
+        vbox.setContentsMargins(0, 0, 0, 0)
+        vbox.addWidget(self._console_monitor)
+        self._frame_4.setLayout(vbox)
+
+        h = self.sizeHint().height()
+        self.setSizes([h, 2 * h, 2 * h, h])
+
+
+class QtRunEngineManager_Monitor(QWidget):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+        vbox = QVBoxLayout()
+        hbox = QHBoxLayout()
+        hbox.addWidget(QtReManagerConnection(model))
+        hbox.addWidget(QtReStatusMonitor(model))
+        hbox.addStretch()
+        vbox.addLayout(hbox)
+
+        vbox.addWidget(QtOrganizeQueueWidgets(model), stretch=2)
+
+        self.setLayout(vbox)
+
+
+class QtRunEngineManager_Editor(QWidget):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+        vbox = QVBoxLayout()
+        hbox = QHBoxLayout()
+        hbox.addWidget(QtReEnvironmentControls(model))
+        hbox.addWidget(QtReQueueControls(model))
+        hbox.addWidget(QtReExecutionControls(model))
+        hbox.addWidget(QtReStatusMonitor(model))
+
+        hbox.addStretch()
+        vbox.addLayout(hbox)
+
+        hbox = QHBoxLayout()
+        vbox1 = QVBoxLayout()
+
+        # Register plan editor (opening plans in the editor by double-clicking the plan in the table)
+        pe = QtRePlanEditor(model)
+        pq = QtRePlanQueue(model)
+        pq.registered_item_editors.append(pe.edit_queue_item)
+
+        vbox1.addWidget(pe, stretch=1)
+        vbox1.addWidget(pq, stretch=1)
+        hbox.addLayout(vbox1)
+        vbox2 = QVBoxLayout()
+        vbox2.addWidget(QtReRunningPlan(model), stretch=1)
+        vbox2.addWidget(QtRePlanHistory(model), stretch=2)
+        hbox.addLayout(vbox2)
+        vbox.addLayout(hbox)
+        self.setLayout(vbox)
+
+
+class QtViewer(QTabWidget):
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = model
+
+        self.setTabPosition(QTabWidget.West)
+
+        self._re_manager_monitor = QtRunEngineManager_Monitor(model.run_engine)
+        self.addTab(self._re_manager_monitor, "Monitor Queue")
+
+        self._re_manager_editor = QtRunEngineManager_Editor(model.run_engine)
+        self.addTab(self._re_manager_editor, "Edit and Control Queue")

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -414,7 +414,7 @@ class RunEngineClient:
         try:
             key_seq = self._map_column_labels_to_keys[label]
         except KeyError:
-            raise KeyError("Label 'label' is not found in the map dictionary")
+            raise KeyError(f"Label '{label}' is not found in the map dictionary")
 
         # Follow the path in the dictionary. 'KeyError' exception is raised if a key does not exist
         try:

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -176,6 +176,8 @@ class QtReManagerConnection(QWidget):
         self.model.events.status_changed.connect(self.on_update_widgets)
         self.signal_update_widget.connect(self.slot_update_widgets)
 
+        self._first_connection = False
+
     def _update_widget_states(self):
         connect_active = not self.updates_activated and not self._deactivate_updates
         disconnect_active = self.updates_activated and not self._deactivate_updates
@@ -204,7 +206,18 @@ class QtReManagerConnection(QWidget):
         self._deactivate_updates = False
         self.model.clear_connection_status()
         self._update_widget_states()
-        self.model.manager_connecting_ops()
+
+        # TODO: If the history contains large number of plans and the program is
+        #   disconnected and connected again (Disconnect then Connect buttons), the program
+        #   is likely to freeze (on the stage of inserting items into the table).
+        #   `self._first_connection` is used to prevent data from reloading if this is not
+        #   the first connection. The data is still reloaded once status is checked.
+        #   The reason why the program is freezing is not apparent and it would be useful
+        #   to find the exact reason why this is happening.
+        if not self._first_connection:
+            self.model.manager_connecting_ops()
+            self._first_connection = True
+
         self._start_thread()
 
     def _pb_re_manager_disconnect_clicked(self):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     packages=find_packages(exclude=["docs", "tests"]),
     entry_points={
         "console_scripts": [
+            "queue-monitor = bluesky_widgets.apps.queue_monitor.main:main"
             # 'command = some.module:some_function',
         ],
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The PR contains implementation of a demo program `queue-monitor` based on widgets from the library. The demo program can be used for monitoring, controlling and editing the queue, as well as an application example. The entry point for the application is installed with the package. In addition,  `QtReConsoleMonitor` widget was modified to fix issues with scrolling and flickering. 

<!--
## Screenshots (if appropriate):
-->
**Monitor Queue** tab: default view.
![image](https://user-images.githubusercontent.com/46980826/148688447-2792b2f7-8ba3-4323-bd66-ae3c49cd0c4f.png)

**Monitor Queue** tab: widgets are resizable.
![image](https://user-images.githubusercontent.com/46980826/148688497-eb8daf7d-14ac-4e0a-aab5-f9bd7553f986.png)

**Edit and Control Queue** tab.
![image](https://user-images.githubusercontent.com/46980826/148688515-8b0e2ccf-a33a-4815-8253-be1a93e13d1d.png)

