### PR TITLE
ENH: menu item to activate/deactivate 'Destroy Env' button

### DIFF
--- a/bluesky_widgets/apps/queue_monitor/viewer.py
+++ b/bluesky_widgets/apps/queue_monitor/viewer.py
@@ -4,6 +4,8 @@ from bluesky_widgets.qt import Window
 from .widgets import QtViewer
 from .settings import SETTINGS
 
+from qtpy.QtWidgets import QAction
+
 
 class ViewerModel:
     """
@@ -27,8 +29,30 @@ class Viewer(ViewerModel):
     def __init__(self, *, show=True, title="Demo App"):
         # TODO Where does title thread through?
         super().__init__()
-        widget = QtViewer(self)
-        self._window = Window(widget, show=show)
+
+        self._widget = QtViewer(self)
+        self._window = Window(self._widget, show=show)
+
+        menu_bar = self._window._qt_window.menuBar()
+        menu_item_control = menu_bar.addMenu("Control Actions")
+        self.action_activate_env_destroy = QAction("Activate 'Destroy Environment'", self._window._qt_window)
+        self.action_activate_env_destroy.setCheckable(True)
+        self._update_action_env_destroy_state()
+        self.action_activate_env_destroy.triggered.connect(self._activate_env_destroy_triggered)
+        menu_item_control.addAction(self.action_activate_env_destroy)
+
+        self._widget.model.run_engine.events.status_changed.connect(self.on_update_widgets)
+
+    def _update_action_env_destroy_state(self):
+        env_destroy_activated = self._widget.model.run_engine.env_destroy_activated
+        self.action_activate_env_destroy.setChecked(env_destroy_activated)
+
+    def _activate_env_destroy_triggered(self):
+        env_destroy_activated = self._widget.model.run_engine.env_destroy_activated
+        self._widget.model.run_engine.activate_env_destroy(not env_destroy_activated)
+
+    def on_update_widgets(self, event):
+        self._update_action_env_destroy_state()
 
     @property
     def window(self):

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -288,9 +288,10 @@ class QtReEnvironmentControls(QWidget):
         # 'is_connected' takes values True, False
         worker_exists = status.get("worker_environment_exists", False)
         manager_state = status.get("manager_state", None)
+        env_destroy_activated = self.model.env_destroy_activated
         self._pb_env_open.setEnabled(is_connected and not worker_exists and (manager_state == "idle"))
         self._pb_env_close.setEnabled(is_connected and worker_exists and (manager_state == "idle"))
-        self._pb_env_destroy.setEnabled(is_connected and worker_exists)
+        self._pb_env_destroy.setEnabled(is_connected and worker_exists and env_destroy_activated)
 
     def _pb_env_open_clicked(self):
         try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes to 'queue-monitor' application:

- Option to deactivate the 'Destroy' button for in the environment control widget and run engine model.
- Menu `Control Actions` with a checkable item for activating and deactivating the 'Destroy' button. The destroy button is automatically deactivate each time the environment is closed or a new environment is open. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->

![image](https://user-images.githubusercontent.com/46980826/153077372-c5f7f75f-285a-404d-8d6e-e886159f571d.png)
