### PR TITLE
Fix: eliminate infinite wait when environment fails to load

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -992,14 +992,14 @@ class RunEngineClient:
         # Wait for the environment to be created.
         if timeout:
             t_stop = time.time() + timeout
-        while True:
-            self.load_re_manager_status()
-            status2 = self._re_manager_status
-            if status2["worker_environment_exists"] and status2["manager_state"] == "idle":
-                break
-            if timeout and (time.time() > t_stop):
-                raise RuntimeError("Failed to start RE Worker: timeout occurred")
-            time.sleep(0.5)
+            while True:
+                self.load_re_manager_status()
+                status2 = self._re_manager_status
+                if status2["worker_environment_exists"] and status2["manager_state"] == "idle":
+                    break
+                if timeout and (time.time() > t_stop):
+                    raise RuntimeError("Failed to start RE Worker: timeout occurred")
+                time.sleep(0.5)
 
         self.activate_env_destroy(False)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix for the bug in that caused the code to get stuck in the infinite loop if the environment fails to open and no timeout is specified. 

