### PR TITLE
Update combo box with the list of allowed items (plans) when the list is changed at the server

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -50,7 +50,9 @@ class RunEngineClient:
         self._re_manager_status_update_period = 0.2
 
         self._allowed_devices = {}
+        self._allowed_devices_uid = ""
         self._allowed_plans = {}
+        self._allowed_plans_uid = ""
         self._plan_queue_items = []
         # Dictionary key: item uid, value: item pos in queue:
         self._plan_queue_items_pos = {}
@@ -155,6 +157,12 @@ class RunEngineClient:
                 new_history_uid = self._re_manager_status.get("plan_history_uid", "")
                 if new_history_uid != self._plan_history_uid:
                     self.load_plan_history()
+                new_allowed_plans_uid = self._re_manager_status.get("plans_allowed_uid", "")
+                if new_allowed_plans_uid != self._allowed_plans_uid:
+                    self.load_allowed_plans()
+                new_allowed_devices_uid = self._re_manager_status.get("devices_allowed_uid", "")
+                if new_allowed_devices_uid != self._allowed_devices_uid:
+                    self.load_allowed_devices()
 
             except CommTimeoutError:
                 self._re_manager_connected = False
@@ -176,6 +184,7 @@ class RunEngineClient:
                 raise RuntimeError(f"Failed to load list of allowed devices: {result['msg']}")
             self._allowed_devices.clear()
             self._allowed_devices.update(result["devices_allowed"])
+            self._allowed_devices_uid = result["devices_allowed_uid"]
             self.events.allowed_devices_changed(allowed_devices=self._allowed_devices)
         except Exception as ex:
             print(f"Exception: {ex}")
@@ -191,6 +200,7 @@ class RunEngineClient:
                 raise RuntimeError(f"Failed to load list of allowed plans: {result['msg']}")
             self._allowed_plans.clear()
             self._allowed_plans.update(result["plans_allowed"])
+            self._allowed_plans_uid = result["plans_allowed_uid"]
             self.events.allowed_plans_changed(allowed_plans=self._allowed_plans)
         except Exception as ex:
             print(f"Exception: {ex}")

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -2267,14 +2267,19 @@ class _QtReEditor(QWidget):
         #   The first item in the list is selected if the value is set to "".
         #   No element selected if the element with the given name is not in the list.
 
+        def lower(s):
+            return s.lower()
+
         if self._current_item_type == "plan":
             allowed_item_names = self.model.get_allowed_plan_names()
+            allowed_item_names.sort(key=lower)
             if (not self._current_plan_name) and (allowed_item_names):
                 self._current_plan_name = allowed_item_names[0]
             item_name = self._current_plan_name
 
         elif self._current_item_type == "instruction":
             allowed_item_names = self.model.get_allowed_instruction_names()
+            allowed_item_names.sort(key=lower)
             if (not self._current_instruction_name) and (allowed_item_names):
                 self._current_instruction_name = allowed_item_names[0]
             item_name = self._current_instruction_name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Extended functionality of the control widgets to download lists of allowed plans and devices when those lists are changed at the server. The items in the combo box with the list of allowed plans in the plan editor is also updated when the list is changed.
In the initial implementation of the widgets it was assumed that the lists of allowed plans and devices are static and rarely change (it used to require restarting the Queue Server). This PR extends functionality to support dynamically changed lists. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addresses the issue https://github.com/bluesky/bluesky-widgets/issues/171

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The updated version of `queue-monitor` was manually tested.
