### PR TITLE
Rename vars

### DIFF
--- a/bluesky_widgets/apps/queue_monitor/main.py
+++ b/bluesky_widgets/apps/queue_monitor/main.py
@@ -10,26 +10,40 @@ from .settings import SETTINGS
 def main(argv=None):
     parser = argparse.ArgumentParser(description="BlueSky Queue Monitor")
     parser.add_argument(
-        "--zmq-control",
+        "--zmq-control-addr",
         help="Address of control socket of RE Manager. If the address "
         "is passed as a CLI parameter, it overrides the address specified with "
-        "QSERVER_ZMQ_CONTROL_ADDRESS environment variable.",
+        "QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Default address is "
+        "used if the parameter or the environment variable are not specified.",
+    )
+    parser.add_argument(
+        "--zmq-control",
+        help="The parameter is deprecated and will be removed. Use --zmq-control-addr instead.",
+    )
+    parser.add_argument(
+        "--zmq-info-addr",
+        help="Address of PUB-SUB socket of RE Manager. If the address "
+        "is passed as a CLI parameter, it overrides the address specified with "
+        "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
+        "used if the parameter or the environment variable are not specified.",
     )
     parser.add_argument(
         "--zmq-publish",
-        help="Address of PUB-SUB socket of RE Manager. If the address "
-        "is passed as a CLI parameter, it overrides the address specified with "
-        "QSERVER_ZMQ_PUBLISH_ADDRESS environment variable.",
+        help="The parameter is deprecated and will be removed. Use --zmq-info-addr instead.",
     )
     args = parser.parse_args(argv)
 
     # The priority is first to check if an address is passed as a parameter and then
     #   check if the environment variables are set. Otherwise use the default local addresses.
     #   (The default addresses are typically used in demos.)
-    zmq_control = args.zmq_control or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
-    zmq_publish = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
-    SETTINGS.zmq_re_manager_control_addr = zmq_control
-    SETTINGS.zmq_re_manager_publish_addr = zmq_publish
+    zmq_control_addr = args.zmq_control or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
+    zmq_info_addr = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
+    if "QSERVER_ZMQ_PUBLISH_ADDRESS" in os.environ:
+        print("WARNING: Environment variable QSERVER_ZMQ_PUBLISH_ADDRESS is deprecated and will be removed.")
+        print("    Use QSERVER_ZMQ_CONTROL_ADDRESS environment variable instead.")
+    zmq_info_addr = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
+    SETTINGS.zmq_re_manager_control_addr = zmq_control_addr
+    SETTINGS.zmq_re_manager_info_addr = zmq_info_addr
 
     with gui_qt("BlueSky Queue Monitor"):
         viewer = Viewer()  # noqa: 401

--- a/bluesky_widgets/apps/queue_monitor/main.py
+++ b/bluesky_widgets/apps/queue_monitor/main.py
@@ -11,6 +11,7 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description="BlueSky Queue Monitor")
     parser.add_argument(
         "--zmq-control-addr",
+        default=None,
         help="Address of control socket of RE Manager. If the address "
         "is passed as a CLI parameter, it overrides the address specified with "
         "QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Default address is "
@@ -18,10 +19,12 @@ def main(argv=None):
     )
     parser.add_argument(
         "--zmq-control",
+        default=None,
         help="The parameter is deprecated and will be removed. Use --zmq-control-addr instead.",
     )
     parser.add_argument(
         "--zmq-info-addr",
+        default=None,
         help="Address of PUB-SUB socket of RE Manager. If the address "
         "is passed as a CLI parameter, it overrides the address specified with "
         "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
@@ -29,6 +32,7 @@ def main(argv=None):
     )
     parser.add_argument(
         "--zmq-publish",
+        default=None,
         help="The parameter is deprecated and will be removed. Use --zmq-info-addr instead.",
     )
     args = parser.parse_args(argv)
@@ -36,12 +40,21 @@ def main(argv=None):
     # The priority is first to check if an address is passed as a parameter and then
     #   check if the environment variables are set. Otherwise use the default local addresses.
     #   (The default addresses are typically used in demos.)
-    zmq_control_addr = args.zmq_control or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
-    zmq_info_addr = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
+    zmq_control_addr = args.zmq_control_addr
+    zmq_control_addr = zmq_control_addr or args.zmq_control
+    if args.zmq_control is not None:
+        print("The parameter --zmq-control is deprecated and will be removed. Use --zmq-control-addr instead.")
+    zmq_control_addr = zmq_control_addr or os.environ.get("QSERVER_ZMQ_CONTROL_ADDRESS", None)
+
+    zmq_info_addr = args.zmq_info_addr
+    if args.zmq_publish is not None:
+        print("The parameter --zmq-publish is deprecated and will be removed. Use --zmq-info-addr instead.")
+    zmq_info_addr = zmq_info_addr or args.zmq_publish
+    zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_INFO_ADDRESS", None)
     if "QSERVER_ZMQ_PUBLISH_ADDRESS" in os.environ:
         print("WARNING: Environment variable QSERVER_ZMQ_PUBLISH_ADDRESS is deprecated and will be removed.")
-        print("    Use QSERVER_ZMQ_CONTROL_ADDRESS environment variable instead.")
-    zmq_info_addr = args.zmq_publish or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
+        print("    Use QSERVER_ZMQ_INFO_ADDRESS environment variable instead.")
+    zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
     SETTINGS.zmq_re_manager_control_addr = zmq_control_addr
     SETTINGS.zmq_re_manager_info_addr = zmq_info_addr
 

--- a/bluesky_widgets/apps/queue_monitor/settings.py
+++ b/bluesky_widgets/apps/queue_monitor/settings.py
@@ -1,6 +1,6 @@
 class Settings:
     zmq_re_manager_control_addr = None
-    zmq_re_manager_publish_addr = None
+    zmq_re_manager_info_addr = None
 
 
 SETTINGS = Settings()

--- a/bluesky_widgets/apps/queue_monitor/viewer.py
+++ b/bluesky_widgets/apps/queue_monitor/viewer.py
@@ -14,8 +14,8 @@ class ViewerModel:
 
     def __init__(self):
         self.run_engine = RunEngineClient(
-            zmq_server_address=SETTINGS.zmq_re_manager_control_addr,
-            zmq_subscribe_address=SETTINGS.zmq_re_manager_publish_addr,
+            zmq_control_addr=SETTINGS.zmq_re_manager_control_addr,
+            zmq_info_addr=SETTINGS.zmq_re_manager_info_addr,
         )
 
 

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -14,10 +14,10 @@ class RunEngineClient:
     """
     Parameters
     ----------
-    zmq_server_address : str or None
+    zmq_control_addr : str or None
         Address of ZMQ server (Run Engine Manager). If None, then the default address defined
         in RE Manager code is used. (Default address is ``tcp://localhost:60615``).
-    zmq_subscribe_address : str or None
+    zmq_info_addr : str or None
         ZMQ address of the socket used by RE Manager to publishe console output.
     user_name : str
         Name of the user submitting the plan. The name is saved as a parameter of the queue item
@@ -29,14 +29,12 @@ class RunEngineClient:
         ``user_group_permissions.yaml`` (see documentation for RE Manager).
     """
 
-    def __init__(
-        self, zmq_server_address=None, zmq_subscribe_address=None, user_name="GUI Client", user_group="admin"
-    ):
-        self._client = ZMQCommSendThreads(zmq_server_address=zmq_server_address)
+    def __init__(self, zmq_control_addr=None, zmq_info_addr=None, user_name="GUI Client", user_group="admin"):
+        self._client = ZMQCommSendThreads(zmq_server_address=zmq_control_addr)
         self.set_map_param_labels_to_keys()
 
         # Address of remote 0MQ socket used to publish RE Manager console output
-        self._zmq_subscribe_addr = zmq_subscribe_address
+        self._zmq_info_addr = zmq_info_addr
         self._stop_console_monitor = False
 
         # User name and group are hard coded for now
@@ -1240,7 +1238,7 @@ class RunEngineClient:
 
     def start_console_output_monitoring(self):
         self._stop_console_monitor = False
-        self._rco = ReceiveConsoleOutput(zmq_subscribe_addr=self._zmq_subscribe_addr, timeout=200)
+        self._rco = ReceiveConsoleOutput(zmq_subscribe_addr=self._zmq_info_addr, timeout=200)
 
     def stop_console_output_monitoring(self):
         self._stop_console_monitor = True


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Renamed parameters and environment variables to match standard names used in https://github.com/bluesky/bluesky-queueserver/pull/234:

- Renamed parameters of `RunEngineClient` model to `zmq_control_addr` and `zmq_info_addr` (this may break existing code).
- Renamed CLI parameters of `queue-monitor` to `--zmq-control-addr` and `--zmq-info-addr`. Old parameters are still supported.
- Renamed environment variables used to set addresses to `QSERVER_ZMQ_SERVER_ADDRESS` and `QSERVER_ZMQ_INFO_ADDRESS`. Old environment variables are still supported.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changes are made to standardize parameter names across the existing packages and applications.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The changes were tested by manually running `queue-monitor` application with different sets of parameters.

<!--
## Screenshots (if appropriate):
-->
