### PR TITLE
Support for colorbar for RasteredImages and activation of tabs from model (QtFigures) 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9"]
         pip-selectors: ["pyqt5"]
 
       fail-fast: false

--- a/bluesky_widgets/_matplotlib_axes.py
+++ b/bluesky_widgets/_matplotlib_axes.py
@@ -164,6 +164,10 @@ class MatplotlibAxes:
         artist_spec = event.item
         # Remove the artist from our caches.
         artist = self._artists.pop(artist_spec.uuid)
+        # Remove colorbar if it exists
+        if hasattr(artist, "_bsw_colorbar"):
+            cb = getattr(artist, "_bsw_colorbar")
+            cb.remove()
         # Remove it from the canvas.
         artist.remove()
         self._update_and_draw()
@@ -196,6 +200,12 @@ class MatplotlibAxes:
 
     def _construct_image(self, *, array, label, style):
         artist = self.axes.imshow(array, label=label)
+
+        if style.get("show_colorbar", False):
+            cb = self.axes.figure.colorbar(artist)
+            # Keep the reference to the colorbar so that it could be removed with the artist
+            setattr(artist, "_bsw_colorbar", cb)  # bsw - bluesky-widgets
+
         self.axes.relim()  # Recompute data limits.
         self.axes.autoscale_view()  # Rescale the view using those new limits.
         self.draw_idle()

--- a/bluesky_widgets/models/_tests/test_rastered_image.py
+++ b/bluesky_widgets/models/_tests/test_rastered_image.py
@@ -3,7 +3,7 @@ import pytest
 import numpy
 
 from ..plot_builders import RasteredImages
-from ..plot_specs import Axes, Figure
+from ..plot_specs import Axes, Image, Figure
 
 
 @pytest.fixture
@@ -67,6 +67,39 @@ def test_x_y_limits_change_x_y_positive(non_snaking_run, FigureView):
     model.axes.x_limits = model.axes.y_limits = (-0.5, 1.5)
     assert model.x_positive == "right"
     assert model.y_positive == "up"
+    view.close()
+
+
+def test_extent_setting(non_snaking_run, FigureView):
+    """
+    Test if ``RasteredImages.extent`` is properly set.
+    """
+    run = non_snaking_run
+    axes = Axes()
+    Figure((axes,), title="")
+    extent1 = (0, 1, 4, 5)
+    model = RasteredImages("ccd", shape=(2, 2), axes=axes, extent=extent1)
+    view = FigureView(model.figure)
+    model.add_run(run)
+
+    def check_artists(ext):
+        image_found = False
+        for artist in axes.artists:
+            if isinstance(artist, Image):
+                assert "extent" in artist.style
+                assert artist.style["extent"] == ext
+                image_found = True
+        if not image_found:
+            assert "No Image found in the list of artists"
+
+    assert model.extent == extent1
+    check_artists(extent1)
+
+    extent2 = (1, 2, 6, 7)
+    model.extent = extent2
+    assert model.extent == extent2
+    check_artists(extent2)
+
     view.close()
 
 

--- a/bluesky_widgets/models/_tests/test_rastered_image.py
+++ b/bluesky_widgets/models/_tests/test_rastered_image.py
@@ -103,6 +103,39 @@ def test_extent_setting(non_snaking_run, FigureView):
     view.close()
 
 
+def test_show_colorbar_setting(non_snaking_run, FigureView):
+    """
+    Test if ``RasteredImages.show_colorbar`` is properly set.
+    """
+    run = non_snaking_run
+    axes = Axes()
+    Figure((axes,), title="")
+    model = RasteredImages("ccd", shape=(2, 2), axes=axes, show_colorbar=True)
+    view = FigureView(model.figure)
+    model.add_run(run)
+
+    def check_artists(value):
+        image_found = False
+        for artist in axes.artists:
+            if isinstance(artist, Image):
+                assert "show_colorbar" in artist.style
+                assert artist.style["show_colorbar"] == value
+                image_found = True
+        if not image_found:
+            assert "No Image found in the list of artists"
+
+    assert model.show_colorbar is True
+    check_artists(True)
+
+    # Check if setting the property changes the style of the artists in the next image
+    model.show_colorbar = False
+    model.add_run(run)
+    assert model.show_colorbar is False
+    check_artists(False)
+
+    view.close()
+
+
 def test_non_snaking_image_data(non_snaking_run, FigureView):
     run = non_snaking_run
     model = RasteredImages("ccd", shape=(2, 2))

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -680,7 +680,7 @@ class RasteredImages:
     @extent.setter
     def extent(self, value):
         self._extent = value
-        for artist in self.axes.artist:
+        for artist in self.axes.artists:
             if isinstance(artist, Image):
                 artist.style.update({"extent": value})
 

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -567,6 +567,8 @@ class RasteredImages:
     y_positive : String, optional
         Defines the positive direction of the y axis, takes the values 'up'
         (default) or 'down'.
+    show_colorbar: boolean
+        Show colorbar for the image.
 
     Attributes
     ----------
@@ -604,6 +606,7 @@ class RasteredImages:
         extent=None,
         x_positive="right",
         y_positive="up",
+        show_colorbar=False,
     ):
         super().__init__()
 
@@ -645,6 +648,7 @@ class RasteredImages:
         self._extent = extent
         self._x_positive = x_positive
         self._y_positive = y_positive
+        self._show_colorbar = bool(show_colorbar)
 
         self._run_manager = RunManager(max_runs, needs_streams)
         self._run_manager.events.run_ready.connect(self._add_image)
@@ -726,10 +730,28 @@ class RasteredImages:
             self.axes.y_limits = (ymin, ymax)
             self._y_positive = value
 
+    @property
+    def show_colorbar(self):
+        """
+        Include colorbar with the next displayed image (``True``) or show the image without
+        colorbar. The setting does not influence the image that is already being displayed.
+        The property may be used to modify the respective parameter of the constructor.
+        """
+        return self._show_colorbar
+
+    @show_colorbar.setter
+    def show_colorbar(self, show_colorbar):
+        self._show_colorbar = bool(show_colorbar)
+
     def _add_image(self, event):
         run = event.run
         func = functools.partial(self._transform, field=self.field)
-        style = {"cmap": self._cmap, "clim": self._clim, "extent": self._extent}
+        style = {
+            "cmap": self._cmap,
+            "clim": self._clim,
+            "extent": self._extent,
+            "show_colorbar": self._show_colorbar,
+        }
         image = Image.from_run(func, run, label=self.field, style=style)
         self._run_manager.track_artist(image, [run])
         md = run.metadata["start"]

--- a/bluesky_widgets/models/plot_builders.py
+++ b/bluesky_widgets/models/plot_builders.py
@@ -733,9 +733,9 @@ class RasteredImages:
     @property
     def show_colorbar(self):
         """
-        Include colorbar with the next displayed image (``True``) or show the image without
-        colorbar. The setting does not influence the image that is already being displayed.
-        The property may be used to modify the respective parameter of the constructor.
+        Display colorbar for the new images (``True``) or show the images without colorbar (``False``).
+        The setting does not influence the image that is already being displayed. The property
+        may be used to modify the value that was passed with the respective parameter of the constructor.
         """
         return self._show_colorbar
 

--- a/bluesky_widgets/qt/_tests/conftest.py
+++ b/bluesky_widgets/qt/_tests/conftest.py
@@ -6,6 +6,7 @@ from bluesky_kafka.tests.conftest import (  # noqa
     hw,
     pytest_addoption,
     kafka_bootstrap_servers,
+    broker_authorization_config,
     publisher_factory,
     temporary_topics,
 )

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -175,6 +175,7 @@ class QtFigure(QWidget):
         super().__init__(parent)
         self.model = model
         self.figure = matplotlib.figure.Figure()
+        self.figure.set_tight_layout(True)
         # TODO Let Figure give different options to subplots here,
         # but verify that number of axes created matches the number of axes
         # specified.

--- a/bluesky_widgets/qt/figures.py
+++ b/bluesky_widgets/qt/figures.py
@@ -70,6 +70,7 @@ class QtFigures(QTabWidget):
             self._add_figure(figure_spec)
         self._threadsafe_connect(model.events.added, self._on_figure_added)
         self._threadsafe_connect(model.events.removed, self._on_figure_removed)
+        self._threadsafe_connect(model.events.active_index, self._on_active_index_changed)
 
         # This setup for self._threadsafe_connect.
 
@@ -158,6 +159,10 @@ class QtFigures(QTabWidget):
     def _on_tab_changed(self, index):
         "Update the active_index in the FigureList."
         self.model.active_index = index
+
+    def _on_active_index_changed(self, event):
+        "Activate tab based on the updated active index in the FigureList."
+        self.setCurrentIndex(event.value)
 
 
 class QtFigure(QWidget):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ release = bluesky_widgets.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The PR contains minor fixes and implementation of simple options to existing classes:

- Fixed typo in variable name in implementation of `RasteredImages.extent` property.
- Set 'tight layout' for Matplotlib figures (`QtFigure`), which significantly reduces wasted screen space, especially if plots contain colorbars.
- New `QtFigures._on_active_index_changed()` event handler that allows to programmatically activate a tab by setting `FigureList.active_index`.
- Implemented an option to show colorbars for image plots. New boolean parameter `show_colorbar` of `RasteredImages.__init__()` enables/disables colorbars for the created image plots. The `RasteredImages.show_colorbar` property changes the setting for the future plots (not the images that are being plotted).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The changes were necessary to complete initial implementation of https://github.com/NSLS-II-SRX/srx-gui 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were implemented.

<!--
## Screenshots (if appropriate):
-->
