### PR TITLE
Modify RunEngineClient to use `bluesky-queueserver-api`. Support for HTTP.

### DIFF
--- a/bluesky_widgets/apps/queue_monitor/main.py
+++ b/bluesky_widgets/apps/queue_monitor/main.py
@@ -12,8 +12,8 @@ def main(argv=None):
     parser.add_argument(
         "--zmq-control-addr",
         default=None,
-        help="Address of control socket of RE Manager. If the address "
-        "is passed as a CLI parameter, it overrides the address specified with "
+        help="Address of control socket of RE Manager, e.g. tcp://localhost:60615. "
+        "If the address is passed as a CLI parameter, it overrides the address specified with "
         "QSERVER_ZMQ_CONTROL_ADDRESS environment variable. Default address is "
         "used if the parameter or the environment variable are not specified.",
     )
@@ -25,8 +25,8 @@ def main(argv=None):
     parser.add_argument(
         "--zmq-info-addr",
         default=None,
-        help="Address of PUB-SUB socket of RE Manager. If the address "
-        "is passed as a CLI parameter, it overrides the address specified with "
+        help="Address of PUB-SUB socket of RE Manager, e.g. 'tcp://localhost:60625'. "
+        "If the address is passed as a CLI parameter, it overrides the address specified with "
         "QSERVER_ZMQ_INFO_ADDRESS environment variable. Default address is "
         "used if the parameter or the environment variable are not specified.",
     )
@@ -34,6 +34,14 @@ def main(argv=None):
         "--zmq-publish",
         default=None,
         help="The parameter is deprecated and will be removed. Use --zmq-info-addr instead.",
+    )
+    parser.add_argument(
+        "--http-server-uri",
+        default=None,
+        help="Address of HTTP Server, e.g. 'http://localhost:60610'. Activates communication "
+        "with Queue Server via HTTP server. If the address is passed as a CLI parameter, "
+        "it overrides the address specified with QSERVER_HTTP_SERVER_URI environment variable. "
+        "Use QSERVER_HTTP_SERVER_API_KEY environment variable to pass an API key for authorization.",
     )
     args = parser.parse_args(argv)
 
@@ -55,8 +63,24 @@ def main(argv=None):
         print("WARNING: Environment variable QSERVER_ZMQ_PUBLISH_ADDRESS is deprecated and will be removed.")
         print("    Use QSERVER_ZMQ_INFO_ADDRESS environment variable instead.")
     zmq_info_addr = zmq_info_addr or os.environ.get("QSERVER_ZMQ_PUBLISH_ADDRESS", None)
-    SETTINGS.zmq_re_manager_control_addr = zmq_control_addr
-    SETTINGS.zmq_re_manager_info_addr = zmq_info_addr
+
+    http_server_uri = args.http_server_uri
+    http_server_uri = http_server_uri or os.environ.get("QSERVER_HTTP_SERVER_URI", None)
+
+    http_server_api_key = os.environ.get("QSERVER_HTTP_SERVER_API_KEY", None)
+
+    if http_server_uri:
+        print("Initializing: communication with Queue Server via HTTP Server ...")
+        SETTINGS.http_server_uri = http_server_uri
+        SETTINGS.http_server_api_key = http_server_api_key
+        SETTINGS.zmq_re_manager_control_addr = None
+        SETTINGS.zmq_re_manager_info_addr = None
+    else:
+        print("Initializing: communication with Queue Server directly via 0MQ sockets ...")
+        SETTINGS.http_server_uri = None
+        SETTINGS.http_server_api_key = None
+        SETTINGS.zmq_re_manager_control_addr = zmq_control_addr
+        SETTINGS.zmq_re_manager_info_addr = zmq_info_addr
 
     with gui_qt("BlueSky Queue Monitor"):
         viewer = Viewer()  # noqa: 401

--- a/bluesky_widgets/apps/queue_monitor/settings.py
+++ b/bluesky_widgets/apps/queue_monitor/settings.py
@@ -1,4 +1,6 @@
 class Settings:
+    http_server_uri = None
+    http_server_api_key = None
     zmq_re_manager_control_addr = None
     zmq_re_manager_info_addr = None
 

--- a/bluesky_widgets/apps/queue_monitor/viewer.py
+++ b/bluesky_widgets/apps/queue_monitor/viewer.py
@@ -16,6 +16,8 @@ class ViewerModel:
         self.run_engine = RunEngineClient(
             zmq_control_addr=SETTINGS.zmq_re_manager_control_addr,
             zmq_info_addr=SETTINGS.zmq_re_manager_info_addr,
+            http_server_uri=SETTINGS.http_server_uri,
+            http_server_api_key=SETTINGS.http_server_api_key,
         )
 
 

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -166,11 +166,14 @@ class RunEngineClient:
         self.load_plan_history()
 
     def load_re_manager_status(self, *, unbuffered=False):
+        # TODO: the new API include efficient implementation of status management, there is no
+        #       need to manage status in the application. The following code should be rewritten
+        #       to take advantage of the existing API features.
         if unbuffered or (time.time() - self._re_manager_status_time > self._re_manager_status_update_period):
             status = self._re_manager_status.copy()
             accessible = self._re_manager_connected
             try:
-                new_manager_status = self._client.status(reload=unbuffered)
+                new_manager_status = self._client.status()
                 self._re_manager_status.clear()
                 self._re_manager_status.update(new_manager_status)
                 self._re_manager_connected = True

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -1075,7 +1075,7 @@ class QtRePlanQueue(QWidget):
                 break
 
         if not item_accepted:
-            print(f"Item {queue_item['name']} was rejected by all registered editors")
+            print(f"Item {queue_item['name']!r} was rejected by all registered editors")
 
     def _pb_move_up_clicked(self):
         try:
@@ -2507,6 +2507,7 @@ class QtRePlanEditor(QWidget):
     def edit_queue_item(self, queue_item):
         self._switch_tab("edit")
         self._plan_editor.edit_queue_item(queue_item)
+        return True  # Indicates that the plan was accepted
 
 
 class DialogBatchUpload(QDialog):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The PR includes the following changes:

- `RunEngineClient` is now using `bluesky-queueserver-api` package instead of raw API to communicate with the Queue Server. The raw API calls were directly replaced with the equivalent API from the package, so the changes are not expected to influence functionality of the widgets. The code may be further changed in the future to utilized `bluesky-queueserver-api` features more efficiently.
-  `RunEngineClient` model was slightly modified to accept initialization parameters `http_server_uri` and `http_server_api_key`, which are necessary for communication with Queue Server over HTTP (supported by `bluesky-queueserver-api` package).
- `queue-monitor` demo application was modified to support HTTP communication. HTTP server URI is set using `--http-server-uri` CLI parameter or `QSERVER_HTTP_SERVER_URI` environment variable. API key is set using `QSERVER_HTTP_SERVER_API_KEY` environment variable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The changes were manually tested by running `queue-monitor` application in various modes.

<!--
## Screenshots (if appropriate):
-->
