### PR TITLE
FIX: patch for a possible bug during selection of rows of plan queue table

### DIFF
--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -1035,7 +1035,10 @@ class QtRePlanQueue(QWidget):
                     self._table.setCurrentCell(rows[-1], 0)
                 for col in range(self._table.columnCount()):
                     item = self._table.item(row, col)
-                    item.setSelected(True)
+                    if item:
+                        item.setSelected(True)
+                    else:
+                        print(f"Plan Queue Table: attempting to select non-existing item: row={row} col={col}")
 
             row_visible = rows[-1]
             item_visible = self._table.item(row_visible, 0)
@@ -1347,7 +1350,10 @@ class QtRePlanHistory(QWidget):
             for row in rows:
                 for col in range(self._table.columnCount()):
                     item = self._table.item(row, col)
-                    item.setSelected(True)
+                    if item:
+                        item.setSelected(True)
+                    else:
+                        print(f"Plan Queue Table: attempting to select non-existing item: row={row} col={col}")
 
             if self._table.currentRow() not in rows:
                 self._table.setCurrentCell(rows[-1], 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix for a rare bug. Since the bug is not reproducible, the bug report is poor and there is no practical way to debug the issue in the settings where the bug was observed, the solution is to check if the table item is available (not `None`) before calling `setSelected()` method and print the error message if the item is `None`. The change should not affect normal operation.
