### PR TITLE
FIX: fixed 'queue_stop_cancel'

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -1165,7 +1165,7 @@ class RunEngineClient:
 
     def queue_stop_cancel(self):
         try:
-            self._client.send_message(method="queue_stop_cancel")
+            self._client.queue_stop_cancel()
         except Exception as ex:
             raise RuntimeError(f"Failed to cancel request to stop the queue: {ex}") from ex
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed behavior of the queue 'Stop' button. The old API call was not changed when the code was converted to `bluesky-queueserver-api` and the widget could not be used to cancel the request to stop the queue. This PR is fixing the bug.

