### PR TITLE
Update default group name for access to plans and devices

### DIFF
--- a/bluesky_widgets/examples/advanced/qt_with_RE_worker.py
+++ b/bluesky_widgets/examples/advanced/qt_with_RE_worker.py
@@ -18,7 +18,7 @@ from bluesky_widgets.models.plot_builders import Lines
 from bluesky_widgets.qt.figures import QtFigure
 from bluesky_widgets.qt import gui_qt
 from bluesky_queueserver.manager.comms import ZMQCommSendThreads
-from bluesky_queueserver_api._default import default_user_group
+from bluesky_queueserver_api._defaults import default_user_group
 
 import sys
 import time

--- a/bluesky_widgets/examples/advanced/qt_with_RE_worker.py
+++ b/bluesky_widgets/examples/advanced/qt_with_RE_worker.py
@@ -18,6 +18,8 @@ from bluesky_widgets.models.plot_builders import Lines
 from bluesky_widgets.qt.figures import QtFigure
 from bluesky_widgets.qt import gui_qt
 from bluesky_queueserver.manager.comms import ZMQCommSendThreads
+from bluesky_queueserver_api._default import default_user_group
+
 import sys
 import time
 
@@ -69,7 +71,7 @@ def main():
                     "args": [["det"], "motor", -5, 5, 11],
                 },
                 "user": "Bluesky Widgets",  # Name of the user submitting item to the queue
-                "user_group": "admin",
+                "user_group": default_user_group,
             },
         )
         if not response["success"]:

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -11,7 +11,7 @@ from bluesky_queueserver.manager.conversions import spreadsheet_to_plan_list
 from bluesky_queueserver_api.zmq import REManagerAPI as REManagerAPI_ZMQ
 from bluesky_queueserver_api.http import REManagerAPI as REManagerAPI_HTTP
 
-from bluesky_queueserver_api._default import default_user_group
+from bluesky_queueserver_api._defaults import default_user_group
 
 class RunEngineClient:
     """

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -11,6 +11,7 @@ from bluesky_queueserver.manager.conversions import spreadsheet_to_plan_list
 from bluesky_queueserver_api.zmq import REManagerAPI as REManagerAPI_ZMQ
 from bluesky_queueserver_api.http import REManagerAPI as REManagerAPI_HTTP
 
+from bluesky_queueserver_api._default import default_user_group
 
 class RunEngineClient:
     """
@@ -42,7 +43,7 @@ class RunEngineClient:
         http_server_uri=None,
         http_server_api_key=None,
         user_name="GUI Client",
-        user_group="admin",
+        user_group=default_user_group,
     ):
         if http_server_uri and (zmq_control_addr or zmq_info_addr):
             raise ValueError(

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -13,6 +13,7 @@ from bluesky_queueserver_api.http import REManagerAPI as REManagerAPI_HTTP
 
 from bluesky_queueserver_api._defaults import default_user_group
 
+
 class RunEngineClient:
     """
     Parameters


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Replace the hard-coded default group name (used in 'user_group_permissions.yaml') with the default group name used in `bluesky-queueserver-api` package. The original name 'admin' is now changed to 'primary' and the widgets are not working with demo startup scripts included in the queue server code.

The changes are necessary for using Queue Server v0.0.17 and older. See https://github.com/bluesky/bluesky-queueserver/pull/259 
