### PR TITLE
RE Manager widgets: do not wait for completion of 're_pause' operations

### DIFF
--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -1210,10 +1210,19 @@ class RunEngineClient:
         except Exception as ex:
             raise RuntimeError(f"Failed to pause the running plan: {ex}") from ex
 
-        def condition(status):
-            return status["manager_state"] in ("idle", "paused")
+        # NOTE: it is unlikely that we need to wait for completion of pausing operation.
+        #   1. The operation may take significant time to complete, meanwhile GUI will stay
+        #      frozen.
+        #   2. Requesting pause multiple times does not cause any issues.
+        #   3. Waiting for completion prevents users from requesting immediate pause once
+        #      the deferred pause is requested. This means that if the scan is stuck and never
+        #      reaches the next setpoint, the users can not try immediate pause or do any other
+        #      operation without restarting GUI.
 
-        self._wait_for_completion(condition=condition, msg="pause the running plan", timeout=timeout)
+        # def condition(status):
+        #     return status["manager_state"] in ("idle", "paused")
+
+        # self._wait_for_completion(condition=condition, msg="pause the running plan", timeout=timeout)
 
     def re_resume(self, timeout=0):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes the issue resulting GUI being blocked indefinitely under certain circumstances. Now the widgets are not waiting
for the results of RE pausing operation (`Pause: Deferred` and `Pause: Immediate` buttons).

Justification:

- The operation of pausing a plan may take significant time, meanwhile GUI stays frozen.

- Once the deferred pause is requested, users are prevented from requesting immediate pause (due to blocked GUI). If the plan is stuck in the middle of the row and unlikely to reach the next setpoint, the user is prevented from performing any operations without restarting the GUI.

- Requesting pause multiple times does not cause any issues.

This is a simple fix for the issue. Better solution may be implemented in the future if needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The issue was observed while testing GUI at SRX beamline.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The behavior was manually tested.

<!--
## Screenshots (if appropriate):
-->
