### PR TITLE
Enable 'pause' buttons whenever Run Engine is in 'running' state.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,5 +8,6 @@ exclude =
     bluesky_widgets/_version.py,
     docs/source/conf.py
     bluesky_widgets/examples/pyFAI_dialog.py,
-ignore = E203, W503  # There are some errors produced by 'black', therefore unavoidable
+# There are some errors produced by 'black', therefore unavoidable    
+ignore = E203, W503  
 max-line-length = 115

--- a/bluesky_widgets/conftest.py
+++ b/bluesky_widgets/conftest.py
@@ -29,7 +29,6 @@ def pytest_collection_modifyitems(session, config, items):
     # actually ensure that qtbot is applied.
 
     if importlib.util.find_spec("qtpy"):
-
         from bluesky_widgets.qt.figures import QtFigure
 
         for item in items:
@@ -43,17 +42,14 @@ def pytest_collection_modifyitems(session, config, items):
 
 _figure_view_params = []
 if importlib.util.find_spec("qtpy"):
-
     from bluesky_widgets.qt.figures import QtFigure
 
     _figure_view_params.append(QtFigure)
 if importlib.util.find_spec("ipywidgets"):
-
     from bluesky_widgets.jupyter.figures import JupyterFigure
 
     _figure_view_params.append(JupyterFigure)
 if importlib.util.find_spec("matplotlib"):
-
     from bluesky_widgets.headless.figures import HeadlessFigure
 
     _figure_view_params.append(HeadlessFigure)
@@ -66,17 +62,14 @@ def FigureView(request):
 
 _figure_views_params = []
 if importlib.util.find_spec("qtpy"):
-
     from bluesky_widgets.qt.figures import QtFigures
 
     _figure_views_params.append(QtFigures)
 if importlib.util.find_spec("ipywidgets"):
-
     from bluesky_widgets.jupyter.figures import JupyterFigures
 
     _figure_views_params.append(JupyterFigures)
 if importlib.util.find_spec("matplotlib"):
-
     from bluesky_widgets.headless.figures import HeadlessFigures
 
     _figure_views_params.append(HeadlessFigures)

--- a/bluesky_widgets/examples/utils/generate_mongo_data.py
+++ b/bluesky_widgets/examples/utils/generate_mongo_data.py
@@ -13,7 +13,6 @@ random_img = SynSignal(func=lambda: np.random.random((5, 10, 10)), name="random_
 
 
 def get_catalog():
-
     RE = RunEngine()
 
     mds = f"mongodb://localhost:27017/databroker-test-{uuid.uuid4()}"

--- a/bluesky_widgets/examples/utils/stream_data_kafka.py
+++ b/bluesky_widgets/examples/utils/stream_data_kafka.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 
 
 def stream_example_data(quiet=False):
-
     bootstrap_servers = "127.0.0.1:9092"
 
     producer_config = {

--- a/bluesky_widgets/headless/figures.py
+++ b/bluesky_widgets/headless/figures.py
@@ -31,7 +31,6 @@ class HeadlessFigures:
     """
 
     def __init__(self, model: FigureList):
-
         self.model = model
         # Map Figure UUID to widget with HeadlessFigure
         self._figures = {}

--- a/bluesky_widgets/models/run_engine_client.py
+++ b/bluesky_widgets/models/run_engine_client.py
@@ -1251,7 +1251,6 @@ class RunEngineClient:
         self._wait_for_completion(condition=condition, msg="resume execution of the plan", timeout=timeout)
 
     def _re_continue_plan(self, *, action, timeout=0):
-
         if action not in ("stop", "abort", "halt"):
             raise RuntimeError(f"Unrecognized action '{action}'")
 
@@ -1288,7 +1287,6 @@ class RunEngineClient:
 
     # def console_monitoring_thread(self, *, callback):
     def console_monitoring_thread(self):
-
         while True:
             try:
                 payload = self._client.console_monitor.next_msg(timeout=0.2)

--- a/bluesky_widgets/qt/_main_window.py
+++ b/bluesky_widgets/qt/_main_window.py
@@ -44,7 +44,6 @@ class Window:
     """
 
     def __init__(self, qt_widget, *, show):
-
         self.qt_widget = qt_widget
 
         self._qt_window = QMainWindow()

--- a/bluesky_widgets/qt/_tests/test_kafka_dispatcher.py
+++ b/bluesky_widgets/qt/_tests/test_kafka_dispatcher.py
@@ -33,7 +33,6 @@ def test_publisher_and_qt_remote_dispatcher(
     """
 
     with temporary_topics(topics=["test.qt.remote.dispatcher"]) as (topic,):
-
         bluesky_publisher = publisher_factory(
             topic=topic,
             key=f"{topic}.key",

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -685,7 +685,6 @@ class PushButtonMinimumWidth(QPushButton):
     """
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
         text = self.text()
         font = self.font()
@@ -696,7 +695,6 @@ class PushButtonMinimumWidth(QPushButton):
 
 
 class QtRePlanQueue(QWidget):
-
     signal_update_widgets = Signal(bool)
     signal_update_selection = Signal(object)
     signal_plan_queue_changed = Signal(object, object)
@@ -1016,7 +1014,6 @@ class QtRePlanQueue(QWidget):
 
     @Slot(object)
     def slot_change_selection(self, selected_item_uids):
-
         rows = [self.model.queue_item_uid_to_pos(_) for _ in selected_item_uids]
 
         # Keep horizontal scroll value while the selection is changed (more consistent behavior)
@@ -1440,7 +1437,6 @@ class QtReRunningPlan(QWidget):
 
     @Slot(object, object)
     def slot_running_item_changed(self, running_item, run_list):
-
         running_item_uid = running_item.get("item_uid", "")
         is_new_item = running_item_uid != self._running_item_uid
         self._running_item_uid = running_item_uid
@@ -1582,7 +1578,6 @@ class QtReRunningPlan(QWidget):
 
 
 class _QtRePlanEditorTable(QTableWidget):
-
     signal_parameters_valid = Signal(bool)
     signal_item_description_changed = Signal(str)
     # The following signal is emitted only if the cell manually modified
@@ -1673,7 +1668,6 @@ class _QtRePlanEditorTable(QTableWidget):
         self.setRowCount(0)
 
     def _item_to_params(self, item):
-
         if item is None:
             return [], {}, [], []
 
@@ -2020,7 +2014,6 @@ class _QtRePlanEditorTable(QTableWidget):
             if column == 1:
                 is_checked = table_item.checkState() == Qt.Checked
                 if self._params[row]["is_value_set"] != is_checked:
-
                     if is_checked and self._params[row]["value"] == inspect.Parameter.empty:
                         self._params[row]["value"] = self._params[row]["parameters"].default
 
@@ -2039,7 +2032,6 @@ class _QtRePlanEditorTable(QTableWidget):
 
 
 class _QtReViewer(QWidget):
-
     signal_update_widgets = Signal()
     signal_update_selection = Signal(int)
     signal_edit_queue_item = Signal(object)
@@ -2176,7 +2168,6 @@ class _QtReViewer(QWidget):
 
 
 class _QtReEditor(QWidget):
-
     signal_update_widgets = Signal()
     signal_switch_tab = Signal(str)
     signal_allowed_plan_changed = Signal()
@@ -2299,7 +2290,6 @@ class _QtReEditor(QWidget):
         self._combo_item_list.setCurrentIndex(index)
 
     def _update_widget_state(self):
-
         is_connected = bool(self.model.re_manager_connected)
 
         self._rb_item_plan.setEnabled(not self._edit_mode_enabled)
@@ -2330,7 +2320,6 @@ class _QtReEditor(QWidget):
         self._queue_item_type = queue_item.get("item_type", None)
 
         if self._queue_item_name and self._queue_item_type and self._queue_item_type in ("plan", "instruction"):
-
             if self._queue_item_type == "instruction":
                 self._current_instruction_name = self._queue_item_name
                 self._rb_item_instruction.setChecked(True)
@@ -2516,7 +2505,6 @@ class QtRePlanEditor(QWidget):
 
 class DialogBatchUpload(QDialog):
     def __init__(self, parent=None, *, current_dir=None, file_type_list=None, additional_parameters=None):
-
         super().__init__(parent)
         self._current_dir = current_dir
         self._file_name = None

--- a/bluesky_widgets/qt/run_engine_client.py
+++ b/bluesky_widgets/qt/run_engine_client.py
@@ -444,12 +444,10 @@ class QtReExecutionControls(QWidget):
         # 'is_connected' takes values True, False
         worker_exists = status.get("worker_environment_exists", False)
         manager_state = status.get("manager_state", None)
-        self._pb_plan_pause_deferred.setEnabled(
-            is_connected and worker_exists and (manager_state == "executing_queue")
-        )
-        self._pb_plan_pause_immediate.setEnabled(
-            is_connected and worker_exists and (manager_state == "executing_queue")
-        )
+        re_state = status.get("re_state", None)
+        pause_enable = manager_state == "executing_queue" or re_state == "running"
+        self._pb_plan_pause_deferred.setEnabled(is_connected and worker_exists and pause_enable)
+        self._pb_plan_pause_immediate.setEnabled(is_connected and worker_exists and pause_enable)
         self._pb_plan_resume.setEnabled(is_connected and worker_exists and (manager_state == "paused"))
         self._pb_plan_stop.setEnabled(is_connected and worker_exists and (manager_state == "paused"))
         self._pb_plan_abort.setEnabled(is_connected and worker_exists and (manager_state == "paused"))

--- a/bluesky_widgets/qt/threading.py
+++ b/bluesky_widgets/qt/threading.py
@@ -22,7 +22,6 @@ def as_generator_function(func: Callable) -> Callable:
 
 
 class WorkerBaseSignals(QObject):
-
     started = Signal()  # emitted when the work is started
     finished = Signal()  # emitted when the work is finished
     returned = Signal(object)  # emitted with return value
@@ -213,7 +212,6 @@ class FunctionWorker(WorkerBase):
 
 
 class GeneratorWorkerSignals(WorkerBaseSignals):
-
     yielded = Signal(object)  # emitted with yielded values (if generator used)
     paused = Signal()  # emitted when a running job has successfully paused
     resumed = Signal()  # emitted when a paused job has successfully resumed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Small change in the behavior of RE Manager control widgets: 'Pause Deferred' and 'Pause Immediate' buttons are now activated whenever the Run Engine is in 'running' state. The buttons can be used to pause a running plan, started in the worker directly using Jupyter Console (worker in IPython kernel mode), bypassing the manager. 

The buttons are also activated when the manager is switched to the 'executing_queue' mode, which happens immediated after the queue is started by the manager. This makes GUI look more responsive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The feature was manually tested.

<!--
## Screenshots (if appropriate):
-->
