### PR TITLE
Fixed bug in QtRemoteDispatcher

### DIFF
--- a/bluesky_widgets/qt/kafka_dispatcher.py
+++ b/bluesky_widgets/qt/kafka_dispatcher.py
@@ -92,7 +92,7 @@ class QtRemoteDispatcher(QObject):
         while continue_polling():
             try:
                 # there should maybe be a poll method on the dispatcher
-                msg = self._dispatcher._bluesky_consumer.consumer.poll(
+                msg = self._dispatcher._bluesky_consumer._consumer.poll(
                     self._dispatcher._bluesky_consumer.polling_duration
                 )
                 if msg is None:
@@ -116,7 +116,7 @@ class QtRemoteDispatcher(QObject):
                                 # doc.
                                 logger.debug("keep waiting for a start document")
                                 return
-                        yield self._dispatcher._bluesky_consumer.consumer, msg.topic(), name, document
+                        yield self._dispatcher._bluesky_consumer._consumer, msg.topic(), name, document
                     except Exception as exc:
                         logger.exception(exc)
             except Exception as exc:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The QtRemoteDispatcher class had an outdated name for one of the objects inside the dispatcher it was creating, which caused the entire class to crash when used. Fixing the name (`_bluesky_consumer.consumer` -> `_bluesky_consumer._consumer`) restores functionality.

See the code in https://github.com/bluesky/bluesky-kafka/blob/main/bluesky_kafka/__init__.py#L149 and https://github.com/bluesky/bluesky-kafka/commit/e9001b7485d12dd3f139744a3603b8a081d0ed0f which changed from `consumer` to `_consumer`

## How Has This Been Tested?
Tested with a containerized beamline running Kafka. Confirmed that QtRemoteDispatcher now instantiates correctly, and dispatches correctly.
